### PR TITLE
Fix dependency binplace on Windows and Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,24 +211,22 @@ if (${K4A_INSTALL_NEEDED})
   set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${K4A_DLL_FILES})
 
   # We need to copy the DLLs into the CATKIN_PACKAGE_LIB_DESTINATION so
-  # the node executable can find them on launch
-  if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
-    set(DLL_COPY_DIRECTORY "${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_BIN_DESTINATION}")
-  elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    set(DLL_COPY_DIRECTORY "${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_LIB_DESTINATION}")
-  endif()
+  # the node executable can find them on launch, and CATKIN_PACKAGE_BIN_DESTINATION
+  # so the nodelet can find them on launch
+  set(DLL_COPY_DIRECTORY "${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_BIN_DESTINATION};${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_LIB_DESTINATION}")
 
-  file(MAKE_DIRECTORY "${DLL_COPY_DIRECTORY}")
+  foreach(DIRECTORY ${DLL_COPY_DIRECTORY})
+    file(MAKE_DIRECTORY "${DIRECTORY}")
+  endforeach(DIRECTORY)
 
   foreach(DLL ${K4A_DLL_FILES})
-    file(COPY "${DLL}" DESTINATION "${DLL_COPY_DIRECTORY}")
-    
-    get_filename_component(DLL_NAME ${DLL} NAME)
-
-    message(STATUS "Copied dll from ${DLL_NAME} to ${DLL_COPY_DIRECTORY}")
-
-    # Tell cmake that we need to clean up these DLLs on a "make clean"
-    set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "${DLL_COPY_DIRECTORY}/${DLL_NAME}")
+    foreach(DIRECTORY ${DLL_COPY_DIRECTORY})
+      file(COPY "${DLL}" DESTINATION "${DIRECTORY}")
+      get_filename_component(DLL_NAME ${DLL} NAME)
+      message(STATUS "Copied dll from ${DLL_NAME} to ${DIRECTORY}")
+      # Tell cmake that we need to clean up these DLLs on a "make clean"
+      set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "${DIRECTORY}/${DLL_NAME}")
+    endforeach(DIRECTORY)
   endforeach(DLL)
   
 endif()

--- a/cmake/azure-kinect-sensor-sdk-config-version.cmake
+++ b/cmake/azure-kinect-sensor-sdk-config-version.cmake
@@ -7,7 +7,8 @@ find_file(versionfile "version.txt"
       NO_DEFAULT_PATH)
 
 if(NOT versionfile)
-  message(FATAL_ERROR "Azure Kinect SDK is not installed properly. It must be installed to the standard install location.")
+  message(STATUS "Azure Kinect SDK is not installed to Program Files.")
+  return()
 endif()
 
 set(versionfilecontents "0.0.0")

--- a/cmake/azure-kinect-sensor-sdk-install.cmake
+++ b/cmake/azure-kinect-sensor-sdk-install.cmake
@@ -2,11 +2,20 @@
 # Licensed under the MIT License.
 
 message("-- Custom K4A install -- ")
-file(MAKE_DIRECTORY "${DLL_COPY_DIRECTORY}")
-message("Installing to: ${DLL_COPY_DIRECTORY}")
+  # Tell cmake that we need to reconfigure if any of the DLL files change
+  set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${K4A_DLL_FILES})
 
-foreach(DLL ${K4A_DLL_FILES})
-    message("Copying DLL from ${DLL} to ${DLL_COPY_DIRECTORY}")
-    file(COPY "${DLL}" DESTINATION "${DLL_COPY_DIRECTORY}")
-endforeach(DLL)
+  foreach(DIRECTORY ${DLL_COPY_DIRECTORY})
+    file(MAKE_DIRECTORY "${DIRECTORY}")
+  endforeach(DIRECTORY)
+
+  foreach(DLL ${K4A_DLL_FILES})
+    foreach(DIRECTORY ${DLL_COPY_DIRECTORY})
+      file(COPY "${DLL}" DESTINATION "${DIRECTORY}")
+      get_filename_component(DLL_NAME ${DLL} NAME)
+      message(STATUS "Copied dll from ${DLL_NAME} to ${DIRECTORY}")
+      # Tell cmake that we need to clean up these DLLs on a "make clean"
+      set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "${DIRECTORY}/${DLL_NAME}")
+    endforeach(DIRECTORY)
+  endforeach(DLL)
 message("-- Custom K4A install finished -- ")


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #14

### Description of the changes:
- Fix an issue in the refactored CMakeLists.txt file which broke the Windows build if the SDK was installed to Program Files
- Fix the binplacing of the dependency DLLs so that Windows and Linux can find them regardless of the SDK install type and regardless of node/nodelet launch

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

