### PR TITLE
Fix RGB point cloud color spill

### DIFF
--- a/include/azure_kinect_ros_driver/k4a_calibration_transform_data.h
+++ b/include/azure_kinect_ros_driver/k4a_calibration_transform_data.h
@@ -21,12 +21,13 @@
 
 // Project headers
 //
+#include "azure_kinect_ros_driver/k4a_ros_device_params.h"
 
 class K4ACalibrationTransformData
 {
 public:
 
-    void initialize(const k4a::device &device, k4a_depth_mode_t depthMode, k4a_color_resolution_t resolution);
+    void initialize(const k4a::device &device, k4a_depth_mode_t depthMode, k4a_color_resolution_t resolution, K4AROSDeviceParams params);
     int getDepthWidth();
     int getDepthHeight();
     int getColorWidth();

--- a/src/k4a_calibration_transform_data.cpp
+++ b/src/k4a_calibration_transform_data.cpp
@@ -19,8 +19,9 @@
 #include "azure_kinect_ros_driver/k4a_ros_types.h"
 
 void K4ACalibrationTransformData::initialize(const k4a::device &device,
-                                                     const k4a_depth_mode_t depth_mode,
-                                                     const k4a_color_resolution_t resolution)
+                                             const k4a_depth_mode_t depth_mode,
+                                             const k4a_color_resolution_t resolution,
+                                             const K4AROSDeviceParams params)
 {
     k4a_calibration_ = device.get_calibration(depth_mode, resolution);
     k4a_transformation_ = k4a::transformation(k4a_calibration_);
@@ -31,13 +32,21 @@ void K4ACalibrationTransformData::initialize(const k4a::device &device,
     bool colorEnabled = (getColorWidth() * getColorHeight() > 0);
 
     // Create a buffer to store the point cloud
-    if (depthEnabled)
+    if (params.point_cloud && !params.rgb_point_cloud)
     {
         point_cloud_image_ = k4a::image::create(
             K4A_IMAGE_FORMAT_DEPTH16,
             getDepthWidth(),
             getDepthHeight(),
             getDepthWidth() * 3 * (int)sizeof(DepthPixel));
+    }
+    else if (params.point_cloud && params.rgb_point_cloud)
+    {
+        point_cloud_image_ = k4a::image::create(
+            K4A_IMAGE_FORMAT_DEPTH16,
+            getColorWidth(),
+            getColorHeight(),
+            getColorWidth() * 3 * (int)sizeof(DepthPixel));
     }
 
     if (depthEnabled && colorEnabled)


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #27 

### Description of the changes:
- Switch to the color camera point-of-view to render RGB point clouds. This ensures that we only render color pixels seen by the color camera. Color pixels not seen by the depth camera will be invalid (NaN or 0mm distance) and will also not be rendered.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

