### PR TITLE
Fix microsoft/Azure_Kinect_ROS_Driver#21

### DIFF
--- a/include/azure_kinect_ros_driver/k4a_ros_device.h
+++ b/include/azure_kinect_ros_driver/k4a_ros_device.h
@@ -63,6 +63,12 @@ class K4AROSDevice
     void framePublisherThread();
     void imuPublisherThread();
 
+    // Converts a k4a_image_t timestamp to a ros::Time object
+    ros::Time timestampToROS(const std::chrono::microseconds & k4a_timestamp_us);
+
+    // Converts a k4a_imu_sample_t timestamp to a ros::Time object
+    ros::Time timestampToROS(const uint64_t & k4a_timestamp_us);
+
     // ROS Node variables
     ros::NodeHandle node_;
     ros::NodeHandle private_node_;
@@ -104,5 +110,7 @@ class K4AROSDevice
     std::thread frame_publisher_thread_;
     std::thread imu_publisher_thread_;
 };
+
+void printTimestampDebugMessage(const std::string name, const ros::Time & timestamp);
 
 #endif // K4A_ROS_DEVICE_H


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #21

### Description of the changes:
- Add two `timestampToROS()` functions to convert K4A timestamps to ROS timestamps instead of using `ros::Time::now()` to capture the ROS timestamp.
- Set `start_time_` when the first IMU sample is captured instead of setting it immediately after the call to `start_cameras()` because the K4A timestamp does not start increasing immediately after the call.
- Add a `printTimestampDebugMessage()` function to see how the return value of `timestampToROS()` compares to that of `ros::Time::now()`, and to get a sense of how much variability the latency has for each type of capture and how the latency of an image capture compares to that of an IMU sample.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Manually tested the changes. Set the logger level to DEBUG to see the messages printed by `printTimestampDebugMessage()`.
