### PR TITLE
Publish camera_info when subscribed

### DIFF
--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -683,7 +683,7 @@ void K4AROSDevice::framePublisherThread()
         if (params_.depth_enabled)
         {
             // Only do compute if we have subscribers
-            if (ir_raw_publisher_.getNumSubscribers() > 0)
+            if (ir_raw_publisher_.getNumSubscribers() > 0 || ir_raw_camerainfo_publisher_.getNumSubscribers() > 0)
             {
                 // IR images are available in all depth modes
                 result = getIrFrame(capture, ir_raw_frame);
@@ -734,7 +734,7 @@ void K4AROSDevice::framePublisherThread()
                 }
                 
                 // We can only rectify the depth into the color co-ordinates if the color camera is enabled!
-                if (params_.color_enabled && (depth_rect_publisher_.getNumSubscribers() > 0))
+                if (params_.color_enabled && (depth_rect_publisher_.getNumSubscribers() > 0 || depth_rect_camerainfo_publisher_.getNumSubscribers() > 0))
                 {
                     result = getDepthFrame(capture, depth_rect_frame, true /* rectified */);
                 
@@ -761,7 +761,7 @@ void K4AROSDevice::framePublisherThread()
             capture_time = timestampToROS(capture.get_color_image().get_device_timestamp());
             printTimestampDebugMessage("Color image", capture_time);
             
-            if (rgb_raw_publisher_.getNumSubscribers() > 0)
+            if (rgb_raw_publisher_.getNumSubscribers() > 0 || rgb_raw_camerainfo_publisher_.getNumSubscribers() > 0)
             {
                 result = getRbgFrame(capture, rgb_raw_frame);
 
@@ -785,7 +785,7 @@ void K4AROSDevice::framePublisherThread()
             // enabled and processing depth data
             if (params_.depth_enabled && 
                 (calibration_data_.k4a_calibration_.depth_mode != K4A_DEPTH_MODE_PASSIVE_IR) && 
-                (rgb_rect_publisher_.getNumSubscribers() > 0))
+                (rgb_rect_publisher_.getNumSubscribers() > 0 || rgb_rect_camerainfo_publisher_.getNumSubscribers() > 0))
             {
                 result = getRbgFrame(capture, rgb_rect_frame, true /* rectified */);
             


### PR DESCRIPTION
This change allows other nodes to subscribe to only camera_info without
subscribing to the main image topic.

<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #
Current implementation does not allow nodes to subscribe to only camera_info.

### Description of the changes:
- Publish image_raw and camera_info when either of them is subscribed to.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
manual/ad-hoc testing
