### PR TITLE
Add tf_prefix to all frames including links in urdf file

### DIFF
--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -7,7 +7,7 @@ Licensed under the MIT License.
   <arg name="tf_prefix"         default="" />               <!-- Prefix added to tf frame IDs. It typically contains a trailing '_' unless empty. -->
 
   <param name="robot_description"
-    command="$(find xacro)/xacro.py $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro tf_prefix:=$(arg tf_prefix)" />
+    command="xacro $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro tf_prefix:=$(arg tf_prefix)" />
 
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -4,9 +4,10 @@ Licensed under the MIT License.
 -->
 
 <launch>
+  <arg name="tf_prefix" default="" />
 
   <param name="robot_description"
-    textfile="$(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf" />
+    command="$(find xacro)/xacro.py $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro tf_prefix:=$(arg tf_prefix)" />
 
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
@@ -28,5 +29,6 @@ Licensed under the MIT License.
     <param name="fps"               type="int"    value="$(arg fps)" /> 
     <param name="point_cloud"       type="bool"   value="$(arg point_cloud)" /> 
     <param name="rgb_point_cloud"   type="bool"   value="$(arg rgb_point_cloud)" /> 
+    <param name="tf_prefix"         type="string" value="$(arg tf_prefix)" />
   </node>
 </launch>

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -4,7 +4,7 @@ Licensed under the MIT License.
 -->
 
 <launch>
-  <arg name="tf_prefix" default="" />
+  <arg name="tf_prefix"         default="" />               <!-- Prefix added to tf frame IDs. It typically contains a trailing '_' unless empty. -->
 
   <param name="robot_description"
     command="$(find xacro)/xacro.py $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro tf_prefix:=$(arg tf_prefix)" />

--- a/launch/rectify_test.launch
+++ b/launch/rectify_test.launch
@@ -6,7 +6,7 @@ Licensed under the MIT License.
 <launch>
 
   <param name="robot_description"
-    textfile="$(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf" />
+    command="$(find xacro)/xacro.py $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro" />
 
   <arg name="rgb_rect" default="1" />
   <arg name="depth_rect" default="1" />

--- a/launch/rectify_test.launch
+++ b/launch/rectify_test.launch
@@ -6,7 +6,7 @@ Licensed under the MIT License.
 <launch>
 
   <param name="robot_description"
-    command="$(find xacro)/xacro.py $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro" />
+    command="xacro $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro" />
 
   <arg name="rgb_rect" default="1" />
   <arg name="depth_rect" default="1" />

--- a/launch/slam_rtabmap.launch
+++ b/launch/slam_rtabmap.launch
@@ -6,7 +6,7 @@ Licensed under the MIT License.
 <launch>
 
   <param name="robot_description"
-    command="$(find xacro)/xacro.py $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro" />
+    command="xacro $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro" />
 
   <!-- Start the K4A sensor driver -->
   <group ns="k4a" >

--- a/launch/slam_rtabmap.launch
+++ b/launch/slam_rtabmap.launch
@@ -6,7 +6,7 @@ Licensed under the MIT License.
 <launch>
 
   <param name="robot_description"
-      textfile="$(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf" />
+    command="$(find xacro)/xacro.py $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro" />
 
   <!-- Start the K4A sensor driver -->
   <group ns="k4a" >

--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>nodelet</depend>
+  <depend>xacro</depend>
 
   <export>
     <nodelet plugin="${prefix}/nodelet_plugins.xml" />

--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -409,7 +409,7 @@ k4a_result_t K4AROSDevice::getRgbPointCloud(const k4a::capture &capture, sensor_
         return K4A_RESULT_FAILED;
     }
 
-    point_cloud->header.frame_id = calibration_data_.rgb_camera_frame_;
+    point_cloud->header.frame_id = calibration_data_.tf_prefix_ + calibration_data_.rgb_camera_frame_;
     point_cloud->header.stamp = timestampToROS(k4a_depth_frame.get_device_timestamp());
     printTimestampDebugMessage("RGB point cloud", point_cloud->header.stamp);
     point_cloud->height = k4a_bgra_frame.get_height_pixels();
@@ -524,7 +524,7 @@ k4a_result_t K4AROSDevice::getPointCloud(const k4a::capture &capture, sensor_msg
         return K4A_RESULT_FAILED;
     }
 
-    point_cloud->header.frame_id = calibration_data_.depth_camera_frame_;
+    point_cloud->header.frame_id = calibration_data_.tf_prefix_ + calibration_data_.depth_camera_frame_;
     point_cloud->header.stamp = timestampToROS(k4a_depth_frame.get_device_timestamp());
     printTimestampDebugMessage("Point cloud", point_cloud->header.stamp);
 
@@ -603,7 +603,7 @@ k4a_result_t K4AROSDevice::getPointCloud(const k4a::capture &capture, sensor_msg
 
 k4a_result_t K4AROSDevice::getImuFrame(const k4a_imu_sample_t& sample, sensor_msgs::ImuPtr imu_msg)
 {
-    imu_msg->header.frame_id = calibration_data_.imu_frame_;
+    imu_msg->header.frame_id = calibration_data_.tf_prefix_ + calibration_data_.imu_frame_;
     imu_msg->header.stamp = timestampToROS(sample.acc_timestamp_usec);
     printTimestampDebugMessage("IMU", imu_msg->header.stamp);
 
@@ -701,7 +701,7 @@ void K4AROSDevice::framePublisherThread()
                 // Re-sychronize the timestamps with the capture timestamp
                 ir_raw_camera_info.header.stamp = capture_time;
                 ir_raw_frame->header.stamp = capture_time;
-                ir_raw_frame->header.frame_id = calibration_data_.depth_camera_frame_;
+                ir_raw_frame->header.frame_id = calibration_data_.tf_prefix_ + calibration_data_.depth_camera_frame_;
 
                 ir_raw_publisher_.publish(ir_raw_frame);
                 ir_raw_camerainfo_publisher_.publish(ir_raw_camera_info);
@@ -727,7 +727,7 @@ void K4AROSDevice::framePublisherThread()
                     // Re-sychronize the timestamps with the capture timestamp
                     depth_raw_camera_info.header.stamp = capture_time;
                     depth_raw_frame->header.stamp = capture_time;
-                    depth_raw_frame->header.frame_id = calibration_data_.depth_camera_frame_;
+                    depth_raw_frame->header.frame_id = calibration_data_.tf_prefix_ + calibration_data_.depth_camera_frame_;
 
                     depth_raw_publisher_.publish(depth_raw_frame);
                     depth_raw_camerainfo_publisher_.publish(depth_raw_camera_info);
@@ -746,7 +746,7 @@ void K4AROSDevice::framePublisherThread()
                     }
 
                     depth_rect_frame->header.stamp = capture_time;
-                    depth_rect_frame->header.frame_id = calibration_data_.rgb_camera_frame_;
+                    depth_rect_frame->header.frame_id = calibration_data_.tf_prefix_ + calibration_data_.rgb_camera_frame_;
                     depth_rect_publisher_.publish(depth_rect_frame);
 
                     // Re-synchronize the header timestamps since we cache the camera calibration message
@@ -773,7 +773,7 @@ void K4AROSDevice::framePublisherThread()
                 }
 
                 rgb_raw_frame->header.stamp =  capture_time;
-                rgb_raw_frame->header.frame_id = calibration_data_.rgb_camera_frame_;
+                rgb_raw_frame->header.frame_id = calibration_data_.tf_prefix_ + calibration_data_.rgb_camera_frame_;
                 rgb_raw_publisher_.publish(rgb_raw_frame);
 
                 // Re-synchronize the header timestamps since we cache the camera calibration message
@@ -797,7 +797,7 @@ void K4AROSDevice::framePublisherThread()
                 }
 
                 rgb_rect_frame->header.stamp = capture_time;
-                rgb_rect_frame->header.frame_id = calibration_data_.depth_camera_frame_;
+                rgb_rect_frame->header.frame_id = calibration_data_.tf_prefix_ + calibration_data_.depth_camera_frame_;
                 rgb_rect_publisher_.publish(rgb_rect_frame);
 
                 // Re-synchronize the header timestamps since we cache the camera calibration message

--- a/urdf/azure_kinect.urdf.xacro
+++ b/urdf/azure_kinect.urdf.xacro
@@ -3,7 +3,9 @@
  Copyright (c) Microsoft Corporation. All rights reserved.
  Licensed under the MIT License.
  -->
-<robot name="azure-kinect">
+
+<robot name="azure-kinect" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:arg name="tf_prefix" default=""/>
   <material name="black">
     <color rgba="0. 0. 0. 1" />
   </material>
@@ -17,7 +19,7 @@
     <color rgba="0.9 0.9 0.9 1" />
   </material>
 
-  <link name="camera_body">
+  <link name="$(arg tf_prefix)camera_body">
     <visual>
       <origin xyz="0. 0. 0." />
       <geometry>
@@ -27,7 +29,7 @@
     </visual>
   </link>
 
-  <link name="camera_base">
+  <link name="$(arg tf_prefix)camera_base">
     <visual>
       <origin xyz="-0.013 0. 0." />
       <geometry>
@@ -37,7 +39,7 @@
     </visual>
   </link>
 
-  <link name="camera_visor">
+  <link name="$(arg tf_prefix)camera_visor">
     <visual>
       <origin xyz="-0.0128 0. 0." />
       <geometry>
@@ -47,15 +49,15 @@
     </visual>
   </link>
 
-  <joint name="camera_base_to_body" type="fixed">
-    <parent link="camera_base" />
-    <child link="camera_body" />
+  <joint name="$(arg tf_prefix)camera_base_to_body" type="fixed">
+    <parent link="$(arg tf_prefix)camera_base" />
+    <child link="$(arg tf_prefix)camera_body" />
     <origin xyz="-0.0757 0. 0.008" rpy="0. 0. 0." />
   </joint>
 
-  <joint name="camera_base_to_visor" type="fixed">
-    <parent link="camera_base" />
-    <child link="camera_visor" />
+  <joint name="$(arg tf_prefix)camera_base_to_visor" type="fixed">
+    <parent link="$(arg tf_prefix)camera_base" />
+    <child link="$(arg tf_prefix)camera_visor" />
     <origin xyz="0. 0. 0." rpy="0. 0. 0." />
   </joint>
 </robot>


### PR DESCRIPTION
tf_prefix was not prepended to all the published frames in PR #39. This PR fixes the bug.

And also, the frames published by `robot_state_publisher` are hard-coded in the urdf file, and hence inconsistent if `tf_frame` is non-empty. This issue is fixed by generating the robot model at runtime using xacro. 

<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #
`frame_id` of point clouds and IR images do not have `tf_prefix` prepended. The frame IDs in urdf model are hard coded, and can be inconsistent with the published tf frames if `tf_prefix` is non empty.

### Description of the changes:
- Prepend K4ACalibrationTransformData::tf_prefix_ to all frame IDs 
- Generate urdf model at runtime using xacro to prepend tf_prefix to frame IDs  

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
manual/ad-hoc testing
