### PR TITLE
Add recording file playback functionality

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,6 +20,8 @@ The node accepts the following parameters:
 - `fps` (int) : Defaults to `5`. This parameter controls the FPS of the color and depth cameras. The cameras cannot operate at different frame rates. Valid options are `5`, `15`, `30`. Note that some FPS values are not compatible with high color camera resolutions or depth camera resolutions. For more information, see the [Azure Kinect Sensor SDK documentation](https://docs.microsoft.com/en-us/azure/Kinect-dk/hardware-specification#depth-camera-supported-operating-modes).
 - `point_cloud` (bool) : Defaults to `true`. If this parameter is set to `true`, the node will generate a sensor_msgs::PointCloud2 message from the depth camera data. This requires that the `depth_enabled` parameter be `true`.
 - `rgb_point_cloud` (bool) : Defaults to `false`. If this parameter is set to `true`, the node will generate a sensor_msgs::PointCloud2 message from the depth camera data and colorize it using the color camera data. This requires that the `point_cloud` parameter be `true`, and the `color_enabled` parameter be `true`.
+- `recording_file` (string) : If this parameter contains a valid absolute path to a k4arecording file, the node will use the playback api with this file instead of opening a device.
+- `recording_loop_enabled` (bool) : Defaults to `false`. If this parameter is set to `true`, the node will rewind the recording file to the beginning after reaching the last frame. Otherwise the node will stop working after reaching the end of the recording file.
 
 #### Parameter Restrictions
 
@@ -29,6 +31,7 @@ Some example incompatibilities are provided here:
 - The `rgb_point_cloud` parameter requires that both the depth and color camera be enabled. This means that `depth_enabled` and `color_enabled` must both be `true`, `depth_mode`, `color_resolution`, and `fps` must be valid.
 - Some combinations of depth mode / color resolution / FPS are incompatible. The Azure Kinect Sensor SDK will generate an exception and print a log message when this situation is detected. The ROS node will then exit.
 - Enabling `rgb_point_cloud` will restrict the resolution of the emitted point cloud to the overlapping region between the depth and color cameras. This region is significantly smaller than the normal field-of-view of the depth camera.
+- `recording_file` parameter accepts only absolute filepaths. Moreover color gets disabled if the color format is not BGRA32.
 
 ## Topics
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,7 +20,7 @@ The node accepts the following parameters:
 - `fps` (int) : Defaults to `5`. This parameter controls the FPS of the color and depth cameras. The cameras cannot operate at different frame rates. Valid options are `5`, `15`, `30`. Note that some FPS values are not compatible with high color camera resolutions or depth camera resolutions. For more information, see the [Azure Kinect Sensor SDK documentation](https://docs.microsoft.com/en-us/azure/Kinect-dk/hardware-specification#depth-camera-supported-operating-modes).
 - `point_cloud` (bool) : Defaults to `true`. If this parameter is set to `true`, the node will generate a sensor_msgs::PointCloud2 message from the depth camera data. This requires that the `depth_enabled` parameter be `true`.
 - `rgb_point_cloud` (bool) : Defaults to `false`. If this parameter is set to `true`, the node will generate a sensor_msgs::PointCloud2 message from the depth camera data and colorize it using the color camera data. This requires that the `point_cloud` parameter be `true`, and the `color_enabled` parameter be `true`.
-- `recording_file` (string) : If this parameter contains a valid absolute path to a k4arecording file, the node will use the playback api with this file instead of opening a device.
+- `recording_file` (string) : No default value. If this parameter contains a valid absolute path to a k4arecording file, the node will use the playback api with this file instead of opening a device.
 - `recording_loop_enabled` (bool) : Defaults to `false`. If this parameter is set to `true`, the node will rewind the recording file to the beginning after reaching the last frame. Otherwise the node will stop working after reaching the end of the recording file.
 
 #### Parameter Restrictions

--- a/include/azure_kinect_ros_driver/k4a_calibration_transform_data.h
+++ b/include/azure_kinect_ros_driver/k4a_calibration_transform_data.h
@@ -11,6 +11,7 @@
 // Library headers
 //
 #include <k4a/k4a.h>
+#include <k4arecord/playback.h>
 #include <ros/ros.h>
 #include <tf2_ros/static_transform_broadcaster.h>
 #include <tf2/LinearMath/Quaternion.h>
@@ -28,6 +29,7 @@ class K4ACalibrationTransformData
 public:
 
     void initialize(const k4a::device &device, k4a_depth_mode_t depthMode, k4a_color_resolution_t resolution, K4AROSDeviceParams params);
+    void initialize(const k4a_playback_t &k4a_playback_handle, K4AROSDeviceParams params);
     int getDepthWidth();
     int getDepthHeight();
     int getColorWidth();
@@ -50,6 +52,7 @@ public:
     std::string imu_frame_ = "imu_link";
 
 private:
+    void initialize(K4AROSDeviceParams params);
 
     void printCameraCalibration(k4a_calibration_camera_t& calibration);
     void printExtrinsics(k4a_calibration_extrinsics_t& extrinsics);

--- a/include/azure_kinect_ros_driver/k4a_ros_device.h
+++ b/include/azure_kinect_ros_driver/k4a_ros_device.h
@@ -11,6 +11,7 @@
 // Library headers
 //
 #include <k4a/k4a.h>
+#include <k4arecord/playback.h>
 #include <ros/ros.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/Image.h>
@@ -100,6 +101,9 @@ class K4AROSDevice
     // K4A device
     k4a::device k4a_device_;
     K4ACalibrationTransformData calibration_data_;
+
+    // K4A Recording
+    k4a_playback_t k4a_playback_handle_;
 
     ros::Time start_time_;
 

--- a/include/azure_kinect_ros_driver/k4a_ros_device.h
+++ b/include/azure_kinect_ros_driver/k4a_ros_device.h
@@ -8,6 +8,7 @@
 //
 #include <thread>
 #include <atomic>
+#include <mutex>
 
 // Library headers
 //
@@ -108,6 +109,7 @@ class K4AROSDevice
 
     // K4A Recording
     k4a_playback_t k4a_playback_handle_;
+    std::mutex k4a_playback_handle_mutex_;
 
     ros::Time start_time_;
 

--- a/include/azure_kinect_ros_driver/k4a_ros_device.h
+++ b/include/azure_kinect_ros_driver/k4a_ros_device.h
@@ -7,6 +7,7 @@
 // System headers
 //
 #include <thread>
+#include <atomic>
 
 // Library headers
 //
@@ -64,6 +65,9 @@ class K4AROSDevice
     void framePublisherThread();
     void imuPublisherThread();
 
+    // Gets a timestap from one of the captures images
+    std::chrono::microseconds getCaptureTimestamp(const k4a::capture &capture);
+
     // Converts a k4a_image_t timestamp to a ros::Time object
     ros::Time timestampToROS(const std::chrono::microseconds & k4a_timestamp_us);
 
@@ -109,6 +113,13 @@ class K4AROSDevice
 
     // Thread control
     volatile bool running_;
+
+    // Last capture timestamp for synchronizing playback capture and imu thread
+    std::atomic_int64_t last_capture_time_usec_;
+
+    // Last imu timestamp for synchronizing playback capture and imu thread
+    std::atomic_uint64_t last_imu_time_usec_;
+    std::atomic_bool imu_stream_end_of_file_;
 
     // Threads
     std::thread frame_publisher_thread_;

--- a/include/azure_kinect_ros_driver/k4a_ros_device_params.h
+++ b/include/azure_kinect_ros_driver/k4a_ros_device_params.h
@@ -38,7 +38,7 @@
     LIST_ENTRY(rgb_point_cloud, "Add RGB camera data to the point cloud. Requires point_cloud=true and color_enabled=true", bool, false) \
     LIST_ENTRY(tf_prefix, "The prefix prepended to tf frame ID's", std::string, std::string()) \
     LIST_ENTRY(recording_file, "Path to a recording file to open instead of opening a device", std::string, std::string("")) \
-    LIST_ENTRY(recording_loop_enabled, "True if the recording should be rewinded at EOF", bool, false) \
+    LIST_ENTRY(recording_loop_enabled, "True if the recording should be rewound at EOF", bool, false) \
 
 class K4AROSDeviceParams
 {

--- a/include/azure_kinect_ros_driver/k4a_ros_device_params.h
+++ b/include/azure_kinect_ros_driver/k4a_ros_device_params.h
@@ -37,6 +37,8 @@
     LIST_ENTRY(point_cloud, "A PointCloud2 based on depth data. Requires depth_enabled=true, and cannot be used with depth_mode=PASSIVE_IR", bool, true) \
     LIST_ENTRY(rgb_point_cloud, "Add RGB camera data to the point cloud. Requires point_cloud=true and color_enabled=true", bool, false) \
     LIST_ENTRY(tf_prefix, "The prefix prepended to tf frame ID's", std::string, std::string()) \
+    LIST_ENTRY(recording_file, "Path to a recording file to open instead of opening a device", std::string, std::string("")) \
+    LIST_ENTRY(recording_loop_enabled, "True if the recording should be rewinded at EOF", bool, false) \
 
 class K4AROSDeviceParams
 {

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -12,15 +12,17 @@ Licensed under the MIT License.
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
 
-  <arg name="depth_enabled"     default="true" />           <!-- Enable or disable the depth camera -->
-  <arg name="depth_mode"        default="WFOV_UNBINNED" />  <!-- Set the depth camera mode, which affects FOV, depth range, and camera resolution. See Azure Kinect documentation for full details. Valid options: NFOV_UNBINNED, NFOV_2X2BINNED, WFOV_UNBINNED, WFOV_2X2BINNED -->
-  <arg name="color_enabled"     default="true" />           <!-- Enable or disable the color camera -->
-  <arg name="color_resolution"  default="1536P" />          <!-- Resolution at which to run the color camera. Valid options: 720P, 1080P, 1440P, 1536P, 2160P, 3072P -->
-  <arg name="fps"               default="5" />             <!-- FPS to run both cameras at. Valid options are 5, 15, and 30 -->
-  <arg name="point_cloud"       default="true" />           <!-- Generate a point cloud from depth data. Requires depth_enabled -->
-  <arg name="rgb_point_cloud"   default="true" />           <!-- Colorize the point cloud using the RBG camera. Requires color_enabled and depth_enabled -->
-  <arg name="required"         default="false" />          <!-- Argument which specified if the entire launch file should terminate if the node dies -->
-  <arg name="sensor_sn"         default="" />               <!-- Sensor serial number. If none provided, the first sensor will be selected -->
+  <arg name="depth_enabled"           default="true" />           <!-- Enable or disable the depth camera -->
+  <arg name="depth_mode"              default="WFOV_UNBINNED" />  <!-- Set the depth camera mode, which affects FOV, depth range, and camera resolution. See Azure Kinect documentation for full details. Valid options: NFOV_UNBINNED, NFOV_2X2BINNED, WFOV_UNBINNED, WFOV_2X2BINNED -->
+  <arg name="color_enabled"           default="true" />           <!-- Enable or disable the color camera -->
+  <arg name="color_resolution"        default="1536P" />          <!-- Resolution at which to run the color camera. Valid options: 720P, 1080P, 1440P, 1536P, 2160P, 3072P -->
+  <arg name="fps"                     default="5" />             <!-- FPS to run both cameras at. Valid options are 5, 15, and 30 -->
+  <arg name="point_cloud"             default="true" />           <!-- Generate a point cloud from depth data. Requires depth_enabled -->
+  <arg name="rgb_point_cloud"         default="true" />           <!-- Colorize the point cloud using the RBG camera. Requires color_enabled and depth_enabled -->
+  <arg name="required"                default="false" />          <!-- Argument which specified if the entire launch file should terminate if the node dies -->
+  <arg name="sensor_sn"               default="" />               <!-- Sensor serial number. If none provided, the first sensor will be selected -->
+  <arg name="recording_file"          default="" />               <!-- Absolute path to a mkv recording file which will be used with the playback api instead of opening a device -->
+  <arg name="recording_loop_enabled"  default="false" />          <!-- If set to true the recording file will rewind the beginning once end of file is reached -->
 
   <node pkg="azure_kinect_ros_driver" type="node" name="node" output="screen" required="$(arg required)">
     <param name="depth_enabled"     type="bool"   value="$(arg depth_enabled)" /> 
@@ -32,5 +34,7 @@ Licensed under the MIT License.
     <param name="rgb_point_cloud"   type="bool"   value="$(arg rgb_point_cloud)" /> 
     <param name="sensor_sn"         type="string" value="$(arg sensor_sn)" />
     <param name="tf_prefix"         type="string" value="$(arg tf_prefix)" />
+    <param name="recording_file"          type="string" value="$(arg recording_file)" />
+    <param name="recording_loop_enabled"  type="bool"   value="$(arg recording_loop_enabled)" />
   </node>
 </launch>

--- a/src/k4a_calibration_transform_data.cpp
+++ b/src/k4a_calibration_transform_data.cpp
@@ -24,6 +24,22 @@ void K4ACalibrationTransformData::initialize(const k4a::device &device,
                                              const K4AROSDeviceParams params)
 {
     k4a_calibration_ = device.get_calibration(depth_mode, resolution);
+    initialize(params);
+}
+
+void K4ACalibrationTransformData::initialize(const k4a_playback_t &k4a_playback_handle,
+                                             const K4AROSDeviceParams params)
+{
+    if (k4a_playback_get_calibration(k4a_playback_handle, &k4a_calibration_) != K4A_RESULT_SUCCEEDED)
+    {
+        ROS_ERROR("Failed to get playback calibration!");
+        return;
+    }
+    initialize(params);
+}
+
+void K4ACalibrationTransformData::initialize(const K4AROSDeviceParams params)
+{
     k4a_transformation_ = k4a::transformation(k4a_calibration_);
     tf_prefix_ = params.tf_prefix;
 

--- a/src/k4a_calibration_transform_data.cpp
+++ b/src/k4a_calibration_transform_data.cpp
@@ -7,6 +7,7 @@
 
 // System headers
 //
+#include <stdexcept>
 
 // Library headers
 //
@@ -32,8 +33,7 @@ void K4ACalibrationTransformData::initialize(const k4a_playback_t &k4a_playback_
 {
     if (k4a_playback_get_calibration(k4a_playback_handle, &k4a_calibration_) != K4A_RESULT_SUCCEEDED)
     {
-        ROS_ERROR("Failed to get playback calibration!");
-        return;
+        throw std::runtime_error("Failed to get playback calibration!");
     }
     initialize(params);
 }

--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -766,6 +766,7 @@ void K4AROSDevice::framePublisherThread()
         }
         else if (k4a_playback_handle_)
         {
+            std::lock_guard<std::mutex> guard(k4a_playback_handle_mutex_);
             k4a_capture_t capture_t;
             k4a_stream_result_t stream_result = k4a_playback_get_next_capture(k4a_playback_handle_, &capture_t);
 
@@ -1007,6 +1008,7 @@ void K4AROSDevice::imuPublisherThread()
             // compare signed with unsigned shouldn't cause a problem because timestamps should always be positive
             while (last_imu_time_usec_ <= last_capture_time_usec_ && !imu_stream_end_of_file_)
             {
+                std::lock_guard<std::mutex> guard(k4a_playback_handle_mutex_);
                 k4a_stream_result_t stream_result = k4a_playback_get_next_imu_sample(k4a_playback_handle_, &sample);
                 if (stream_result == K4A_STREAM_RESULT_EOF)
                 {

--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -75,12 +75,26 @@ K4AROSDevice::K4AROSDevice(const NodeHandle &n, const NodeHandle &p) : k4a_devic
             break;
         };
 
+        // Disable color if the recording has no color track
+        if (params_.color_enabled && !record_config.color_track_enabled)
+        {
+            ROS_WARN("Disabling color and rgb_point_cloud because recording has no color track");
+            params_.color_enabled = false;
+            params_.rgb_point_cloud = false;
+        }
         // This is necessary because at the moment there are only checks in place which use BgraPixel size
-        if (record_config.color_format != K4A_IMAGE_FORMAT_COLOR_BGRA32)
+        else if (params_.color_enabled && record_config.color_track_enabled && record_config.color_format != K4A_IMAGE_FORMAT_COLOR_BGRA32)
         {
             ROS_WARN("Disabling color and rgb_point_cloud because currently BGRA32 is only supported color format for playback");
             params_.color_enabled = false;
             params_.rgb_point_cloud = false;
+        }
+
+        // Disable depth if the recording has no depth track
+        if (params_.depth_enabled && !record_config.depth_track_enabled)
+        {
+            ROS_WARN("Disabling depth because recording has no depth track");
+            params_.depth_enabled = false;
         }
     }
     else


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #
Feature request for playback functionality:
https://github.com/microsoft/Azure_Kinect_ROS_Driver/issues/45#issuecomment-521723497
#6

Contrary to the suggestion in #6 I implemented this feature in the existing node because the handling compared to a device is almost the same. Only the source of captures/imu samples and device configuration changes when using a recording file

### Description of the changes:
- Adding recording file playback functionality with two additional parameters for the node:
- recording_file: Absolute path to a mkv recording file for playback
- recording_loop_enabled: If set to true, the recording is played in endless mode until the node is shutdown
- color proccessing will be disabled if the color format of the recording file is not BGRA32 because there exists checks in the code which compare image sizes with BGRA32 pixel size

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [ ] I tested my changes with a device
- [x] I tested my changes with a recording file

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
manual/ad-hoc testing with a mkv recording file.
