### PR TITLE
Add body tracking data publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ The camera is fully configurable using a variety of options which can be specifi
 
 However, this node does ***not*** expose all the sensor data from the Azure Kinect Developer Kit hardware. It does not provide access to:
 
-- Body tracking data
 - Microphone array
 
 For more information about how to use the node, please see the [usage guide](docs/usage.md).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -22,6 +22,7 @@ The node accepts the following parameters:
 - `rgb_point_cloud` (bool) : Defaults to `false`. If this parameter is set to `true`, the node will generate a sensor_msgs::PointCloud2 message from the depth camera data and colorize it using the color camera data. This requires that the `point_cloud` parameter be `true`, and the `color_enabled` parameter be `true`.
 - `recording_file` (string) : No default value. If this parameter contains a valid absolute path to a k4arecording file, the node will use the playback api with this file instead of opening a device.
 - `recording_loop_enabled` (bool) : Defaults to `false`. If this parameter is set to `true`, the node will rewind the recording file to the beginning after reaching the last frame. Otherwise the node will stop working after reaching the end of the recording file.
+- `body_tracking_enabled` (bool) : Defaults to `false`. If this parameter is set to `true`, the node will generate visualization_msgs::MarkerArray messages for the body tracking data. This requires that the `depth_enabled` parameter is set to `true` and an installed azure kinect body tracking sdk.
 
 #### Parameter Restrictions
 
@@ -49,6 +50,7 @@ The node emits a variety of topics into its namespace.
 - `ir/image_raw` (`sensor_msgs::Image`) : The raw infrared image from the depth camera sensor. In most depth modes, this image will be illuminated by the infrared illuminator built into the Azure Kinect DK. In `PASSIVE_IR` mode, this image will not be illuminated by the Azure Kinect DK.
 - `ir/camera_info` (`sensor_msgs::CameraInfo`) : Calibration information for the infrared camera, converted from the Azure Kinect Sensor SDK format. Since the depth camera and infrared camera are physically the same camera, this `camera_info` is a copy of the camera info published for the depth camera.
 - `imu` (`sensor_msgs::Imu`) : The intrinsics-corrected IMU sensor stream, provided by the Azure Kinect Sensor SDK. The sensor SDK automatically corrects for IMU intrinsics before sensor data is emitted.
+- `body_tracking_data` (`visualization_msgs::MarkerArray`) : Topic for receiving body tracking data. Each message contains all joints for all bodies for the most recent depth image. The markers are grouped by the [body id](https://microsoft.github.io/Azure-Kinect-Body-Tracking/release/0.9.x/structk4abt__body__t.html#a38fed6c7125f92b41165ffe2e1da9dd4) and the joints are in the same order as in the [joint enum of body tracking sdk](https://microsoft.github.io/Azure-Kinect-Body-Tracking/release/0.9.x/group__btenums.html#ga5fe6fa921525a37dec7175c91c473781). The id field of a marker is calculated by: `body_id * 100 + joint_index` where body_id is the corresponding body id from the body tracking sdk and the joint index is analogue to enum value for joints in the body tracking sdk. Subscribers can calculate the body.id by `floor(marker.id / 100)` and the joint_index by `marker.id % 100`.
 
 ## Azure Kinect Developer Kit Calibration
 

--- a/include/azure_kinect_ros_driver/k4a_ros_device.h
+++ b/include/azure_kinect_ros_driver/k4a_ros_device.h
@@ -23,6 +23,11 @@
 #include <sensor_msgs/Temperature.h>
 #include <image_transport/image_transport.h>
 
+#if defined(K4A_BODY_TRACKING)
+#include <k4abt.hpp>
+#include <visualization_msgs/MarkerArray.h>
+#endif
+
 // Project headers
 //
 #include "azure_kinect_ros_driver/k4a_ros_device_params.h"
@@ -57,6 +62,10 @@ class K4AROSDevice
     k4a_result_t getRbgFrame(const k4a::capture &capture, sensor_msgs::ImagePtr rgb_frame, bool rectified);
 
     k4a_result_t getIrFrame(const k4a::capture &capture, sensor_msgs::ImagePtr ir_image);
+
+#if defined(K4A_BODY_TRACKING)
+    k4a_result_t getBodyMarker(const k4abt_body_t& body, visualization_msgs::MarkerPtr marker_msg, int jointType, ros::Time capture_time);
+#endif
 
   private:
     k4a_result_t renderBGRA32ToROS(sensor_msgs::ImagePtr rgb_frame, k4a::image& k4a_bgra_frame);
@@ -100,6 +109,10 @@ class K4AROSDevice
 
     ros::Publisher pointcloud_publisher_;
 
+#if defined(K4A_BODY_TRACKING)
+    ros::Publisher body_marker_publisher_;
+#endif
+
     // Parameters
     K4AROSDeviceParams params_;
 
@@ -110,6 +123,11 @@ class K4AROSDevice
     // K4A Recording
     k4a_playback_t k4a_playback_handle_;
     std::mutex k4a_playback_handle_mutex_;
+    
+#if defined(K4A_BODY_TRACKING)
+    // Body tracker
+    k4abt::tracker k4abt_tracker_;
+#endif
 
     ros::Time start_time_;
 

--- a/include/azure_kinect_ros_driver/k4a_ros_device_params.h
+++ b/include/azure_kinect_ros_driver/k4a_ros_device_params.h
@@ -39,6 +39,7 @@
     LIST_ENTRY(tf_prefix, "The prefix prepended to tf frame ID's", std::string, std::string()) \
     LIST_ENTRY(recording_file, "Path to a recording file to open instead of opening a device", std::string, std::string("")) \
     LIST_ENTRY(recording_loop_enabled, "True if the recording should be rewound at EOF", bool, false) \
+    LIST_ENTRY(body_tracking_enabled, "True if body joints should be published as a marker array message", bool, false) \
 
 class K4AROSDeviceParams
 {

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -23,6 +23,7 @@ Licensed under the MIT License.
   <arg name="sensor_sn"               default="" />               <!-- Sensor serial number. If none provided, the first sensor will be selected -->
   <arg name="recording_file"          default="" />               <!-- Absolute path to a mkv recording file which will be used with the playback api instead of opening a device -->
   <arg name="recording_loop_enabled"  default="false" />          <!-- If set to true the recording file will rewind the beginning once end of file is reached -->
+  <arg name="body_tracking_enabled"   default="false" />          <!-- If set to true the joint positions will be published as marker arrays -->
 
   <node pkg="azure_kinect_ros_driver" type="node" name="node" output="screen" required="$(arg required)">
     <param name="depth_enabled"     type="bool"   value="$(arg depth_enabled)" /> 
@@ -36,5 +37,6 @@ Licensed under the MIT License.
     <param name="tf_prefix"         type="string" value="$(arg tf_prefix)" />
     <param name="recording_file"          type="string" value="$(arg recording_file)" />
     <param name="recording_loop_enabled"  type="bool"   value="$(arg recording_loop_enabled)" />
+    <param name="body_tracking_enabled"   type="bool"   value="$(arg body_tracking_enabled)" />
   </node>
 </launch>


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #

Feature request for body tracking support mentioned in this issue:
https://github.com/microsoft/Azure_Kinect_ROS_Driver/issues/45#issuecomment-521723497

Testing could only be done with a recording for now.

### Description of the changes:
- Added a parameters for enabling body tracking support
- body_tracking_enabled: If true, the joint data per body is published as Marker Array which can be visualized in RViz.
- All body tracking data of a capture gets published on a single topic "body_tracking_data" and contains the markers grouped by the body ids and for each body the joints in the same order as the body tracking sdk joint enum.
Example:
MarkerArray
  - Markers for body 1
    - joint 0 data
    - joint 1 data
    - joint 2 data
    -  ....
  - Markers for body 2
    - joint 0 data
    - joint 1 data
  - ...
- I did this to keep it simple. Just one topic to subscribe to. Just one message for a capture instead of multiple for each body. So each new message means its for the next capture.
- I used the variable from the CMakeLists.txt to compile the body tracking only when a body tracking sdk is installed

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [ ] I tested my changes with a device
- [x] I tested my changes with a recording (using the code together with my other pull request for playback)

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Manual/ad-hoc testing:
- Started the node with a recording with the new parameters
- Started RViz to check wether the body markers match the depth image of the person

![body_tracking_example](https://user-images.githubusercontent.com/17414522/63131739-08def900-bfbf-11e9-9207-e5865fc7cd10.png)

