### PR TITLE
Fix CameraInfo publisher

### DIFF
--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -713,7 +713,7 @@ void K4AROSDevice::framePublisherThread()
                 capture_time = timestampToROS(capture.get_depth_image().get_device_timestamp());
                 printTimestampDebugMessage("Depth image", capture_time);
 
-                if (depth_raw_publisher_.getNumSubscribers() > 0 || depth_raw_camerainfo_publisher_.getNumSubscriber() > 0)
+                if (depth_raw_publisher_.getNumSubscribers() > 0 || depth_raw_camerainfo_publisher_.getNumSubscribers() > 0)
                 {
                     result = getDepthFrame(capture, depth_raw_frame);
             

--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -713,7 +713,7 @@ void K4AROSDevice::framePublisherThread()
                 capture_time = timestampToROS(capture.get_depth_image().get_device_timestamp());
                 printTimestampDebugMessage("Depth image", capture_time);
 
-                if (depth_raw_publisher_.getNumSubscribers() > 0)
+                if (depth_raw_publisher_.getNumSubscribers() > 0 || depth_raw_camerainfo_publisher_.getNumSubscriber() > 0)
                 {
                     result = getDepthFrame(capture, depth_raw_frame);
             


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #
CameraInfo for raw depth stream was not correctly published in PR #40. Apologies for the bug.

### Description of the changes:
- depth_raw_camerainfo_publisher now publishes CameraInfo if the subscriber is present.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
manual/ad-hoc testing
