### PR TITLE
Color conversion to BGRA for recording files

### DIFF
--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -88,9 +88,7 @@ K4AROSDevice::K4AROSDevice(const NodeHandle &n, const NodeHandle &p) : k4a_devic
         // This is necessary because at the moment there are only checks in place which use BgraPixel size
         else if (params_.color_enabled && record_config.color_track_enabled && record_config.color_format != K4A_IMAGE_FORMAT_COLOR_BGRA32)
         {
-            ROS_WARN("Disabling color and rgb_point_cloud because currently BGRA32 is only supported color format for playback");
-            params_.color_enabled = false;
-            params_.rgb_point_cloud = false;
+            k4a_playback_set_color_conversion(k4a_playback_handle_, K4A_IMAGE_FORMAT_COLOR_BGRA32);
         }
 
         // Disable depth if the recording has neither ir track nor depth track
@@ -743,7 +741,6 @@ k4a_result_t K4AROSDevice::getImuFrame(const k4a_imu_sample_t& sample, sensor_ms
 
     return K4A_RESULT_SUCCEEDED;
 }
-
 
 void K4AROSDevice::framePublisherThread()
 {


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #
#61 
Enables color conversion to BGRA for recording files.

### Description of the changes:
- If a recording file is opened and the color_enabled parameter is set, the conversion to BGRA will be set for the playback handle

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [ ] I tested my changes with a device
- [x] I tested my changes with a recording file

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

manual testing