### PR TITLE
Fix incorrect robot_state_publisher namespace

### DIFF
--- a/launch/rectify_test.launch
+++ b/launch/rectify_test.launch
@@ -14,6 +14,9 @@ Licensed under the MIT License.
   <arg name="point_cloud" default="1" />
   <arg name="rgb_point_cloud" default="1" />
 
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+
   <!-- Start the K4A sensor driver -->
   <group ns="k4a" >
     
@@ -91,7 +94,5 @@ Licensed under the MIT License.
       <param name="required"          value="true" />
     </node>
 
-    <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
-    <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
   </group>
 </launch>

--- a/launch/slam_rtabmap.launch
+++ b/launch/slam_rtabmap.launch
@@ -8,6 +8,9 @@ Licensed under the MIT License.
   <param name="robot_description"
     command="xacro $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro" />
 
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+
   <!-- Start the K4A sensor driver -->
   <group ns="k4a" >
     
@@ -45,8 +48,6 @@ Licensed under the MIT License.
       <param name="required"          value="true" />
     </node>
 
-    <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
-    <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
   </group>
 
   <!-- Start rtabmap_ros node -->


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #38 

### Description of the changes:
- Move robot_state_publisher out of the `k4a` namespace

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

