### PR TITLE
Enable to publish JPEG images without image decompression on the host 

### DIFF
--- a/include/azure_kinect_ros_driver/k4a_ros_device.h
+++ b/include/azure_kinect_ros_driver/k4a_ros_device.h
@@ -17,6 +17,7 @@
 #include <k4arecord/playback.hpp>
 #include <ros/ros.h>
 #include <sensor_msgs/CameraInfo.h>
+#include <sensor_msgs/CompressedImage.h>
 #include <sensor_msgs/Image.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <sensor_msgs/Imu.h>
@@ -60,6 +61,7 @@ class K4AROSDevice
     k4a_result_t getImuFrame(const k4a_imu_sample_t &capture, sensor_msgs::ImuPtr imu_frame);
 
     k4a_result_t getRbgFrame(const k4a::capture &capture, sensor_msgs::ImagePtr rgb_frame, bool rectified);
+    k4a_result_t getJpegRgbFrame(const k4a::capture &capture, sensor_msgs::CompressedImagePtr jpeg_image);
 
     k4a_result_t getIrFrame(const k4a::capture &capture, sensor_msgs::ImagePtr ir_image);
 
@@ -91,6 +93,7 @@ class K4AROSDevice
     image_transport::ImageTransport image_transport_;
 
     image_transport::Publisher  rgb_raw_publisher_;
+    ros::Publisher              rgb_jpeg_publisher_;
     ros::Publisher              rgb_raw_camerainfo_publisher_;
 
     image_transport::Publisher  depth_raw_publisher_;

--- a/include/azure_kinect_ros_driver/k4a_ros_device_params.h
+++ b/include/azure_kinect_ros_driver/k4a_ros_device_params.h
@@ -32,6 +32,7 @@
     LIST_ENTRY(depth_enabled, "True if depth camera should be enabled", bool, true) \
     LIST_ENTRY(depth_mode, "The mode of the depth camera. Options are: NFOV_2X2BINNED, NFOV_UNBINNED, WFOV_2X2BINNED, WFOV_UNBINNED, PASSIVE_IR", std::string, std::string("NFOV_UNBINNED")) \
     LIST_ENTRY(color_enabled, "True if color camera should be enabled", bool, false) \
+    LIST_ENTRY(color_format, "The format of RGB camera. Options are: bgra, jpeg", std::string, std::string("bgra")) \
     LIST_ENTRY(color_resolution, "The resolution of the color camera. Options are: 720P, 1080P, 1440P, 1536P, 2160P, 3072P", std::string, std::string("720P")) \
     LIST_ENTRY(fps, "The FPS of the RGB and Depth cameras. Options are: 5, 15, 30", int, 5) \
     LIST_ENTRY(point_cloud, "A PointCloud2 based on depth data. Requires depth_enabled=true, and cannot be used with depth_mode=PASSIVE_IR", bool, true) \

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -15,6 +15,7 @@ Licensed under the MIT License.
   <arg name="depth_enabled"           default="true" />           <!-- Enable or disable the depth camera -->
   <arg name="depth_mode"              default="WFOV_UNBINNED" />  <!-- Set the depth camera mode, which affects FOV, depth range, and camera resolution. See Azure Kinect documentation for full details. Valid options: NFOV_UNBINNED, NFOV_2X2BINNED, WFOV_UNBINNED, WFOV_2X2BINNED -->
   <arg name="color_enabled"           default="true" />           <!-- Enable or disable the color camera -->
+  <arg name="color_format"            default="bgra" />           <!-- The format of RGB camera. Valid options: bgra, jpeg -->
   <arg name="color_resolution"        default="1536P" />          <!-- Resolution at which to run the color camera. Valid options: 720P, 1080P, 1440P, 1536P, 2160P, 3072P -->
   <arg name="fps"                     default="5" />             <!-- FPS to run both cameras at. Valid options are 5, 15, and 30 -->
   <arg name="point_cloud"             default="true" />           <!-- Generate a point cloud from depth data. Requires depth_enabled -->
@@ -29,6 +30,7 @@ Licensed under the MIT License.
     <param name="depth_enabled"     type="bool"   value="$(arg depth_enabled)" /> 
     <param name="depth_mode"        type="string" value="$(arg depth_mode)" /> 
     <param name="color_enabled"     type="bool"   value="$(arg color_enabled)" /> 
+    <param name="color_format"      type="string" value="$(arg color_format)" />
     <param name="color_resolution"  type="string" value="$(arg color_resolution)" /> 
     <param name="fps"               type="int"    value="$(arg fps)" /> 
     <param name="point_cloud"       type="bool"   value="$(arg point_cloud)" /> 

--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -205,7 +205,17 @@ K4AROSDevice::K4AROSDevice(const NodeHandle &n, const NodeHandle &p) : k4a_devic
     }
     
     // Register our topics
-    rgb_raw_publisher_ = image_transport_.advertise("rgb/image_raw", 1);
+    if (params_.color_format == "jpeg")
+    {
+        // JPEG images are directly published on 'rgb/image_raw/compressed' so that
+        // others can subscribe to 'rgb/image_raw' with compressed_image_transport.
+        // This technique is described in: http://wiki.ros.org/compressed_image_transport#Publishing_compressed_images_directly
+        rgb_jpeg_publisher_ = node_.advertise<CompressedImage>(node_.resolveName("rgb/image_raw") + "/compressed", 1);
+    }
+    else if (params_.color_format == "bgra")
+    {
+        rgb_raw_publisher_ = image_transport_.advertise("rgb/image_raw", 1);
+    }
     rgb_raw_camerainfo_publisher_ = node_.advertise<CameraInfo>("rgb/camera_info", 1);
 
     depth_raw_publisher_ = image_transport_.advertise("depth/image_raw", 1);
@@ -453,6 +463,23 @@ k4a_result_t K4AROSDevice::renderIrToROS(sensor_msgs::ImagePtr ir_image, k4a::im
 
     memcpy(ir_image_data, k4a_ir_frame.get_buffer(), ir_image->height * ir_image->step);
 
+    return K4A_RESULT_SUCCEEDED;
+}
+
+
+k4a_result_t K4AROSDevice::getJpegRgbFrame(const k4a::capture &capture, sensor_msgs::CompressedImagePtr jpeg_image)
+{
+    k4a::image k4a_jpeg_frame = capture.get_color_image();
+
+    if (!k4a_jpeg_frame)
+    {
+        ROS_ERROR("Cannot render Jpeg frame: no frame");
+        return K4A_RESULT_FAILED;
+    }
+
+    const uint8_t *jpeg_frame_buffer = k4a_jpeg_frame.get_buffer();
+    jpeg_image->format = "jpeg";
+    jpeg_image->data.assign(jpeg_frame_buffer, jpeg_frame_buffer + k4a_jpeg_frame.get_size());
     return K4A_RESULT_SUCCEEDED;
 }
 
@@ -860,6 +887,7 @@ void K4AROSDevice::framePublisherThread()
             last_capture_time_usec_ = getCaptureTimestamp(capture).count();
         }
 
+        CompressedImagePtr rgb_jpeg_frame(new CompressedImage);
         ImagePtr rgb_raw_frame(new Image);
         ImagePtr rgb_rect_frame(new Image);
         ImagePtr depth_raw_frame(new Image);
@@ -1010,58 +1038,87 @@ void K4AROSDevice::framePublisherThread()
         {   
             // Only create rgb frame when we are using a device or we have a color image.
             // Recordings may not have synchronized captures. For unsynchronized captures without color image skip rgb frame.
-            if ((rgb_raw_publisher_.getNumSubscribers() > 0 || rgb_raw_camerainfo_publisher_.getNumSubscribers() > 0) &&
-                (k4a_device_ || capture.get_color_image() != nullptr))
+            if (params_.color_format == "jpeg")
             {
-                result = getRbgFrame(capture, rgb_raw_frame);
-
-                if (result != K4A_RESULT_SUCCEEDED)
+                if ((rgb_jpeg_publisher_.getNumSubscribers() > 0 || rgb_raw_camerainfo_publisher_.getNumSubscribers() > 0) &&
+                    (k4a_device_ || capture.get_color_image() != nullptr))
                 {
-                    ROS_ERROR_STREAM("Failed to get RGB frame");
-                    ros::shutdown();
-                    return;
+                    result = getJpegRgbFrame(capture, rgb_jpeg_frame);
+
+                    if (result != K4A_RESULT_SUCCEEDED)
+                    {
+                        ROS_ERROR_STREAM("Failed to get Jpeg frame");
+                        ros::shutdown();
+                        return;
+                    }
+
+                    capture_time = timestampToROS(capture.get_color_image().get_device_timestamp());
+                    printTimestampDebugMessage("Color image", capture_time);
+
+                    rgb_jpeg_frame->header.stamp =  capture_time;
+                    rgb_jpeg_frame->header.frame_id = calibration_data_.tf_prefix_ + calibration_data_.rgb_camera_frame_;
+                    rgb_jpeg_publisher_.publish(rgb_jpeg_frame);
+
+                    // Re-synchronize the header timestamps since we cache the camera calibration message
+                    rgb_raw_camera_info.header.stamp = capture_time;
+                    rgb_raw_camerainfo_publisher_.publish(rgb_raw_camera_info);
                 }
-
-                capture_time = timestampToROS(capture.get_color_image().get_device_timestamp());
-                printTimestampDebugMessage("Color image", capture_time);
-
-                rgb_raw_frame->header.stamp =  capture_time;
-                rgb_raw_frame->header.frame_id = calibration_data_.tf_prefix_ + calibration_data_.rgb_camera_frame_;
-                rgb_raw_publisher_.publish(rgb_raw_frame);
-
-                // Re-synchronize the header timestamps since we cache the camera calibration message
-                rgb_raw_camera_info.header.stamp = capture_time;
-                rgb_raw_camerainfo_publisher_.publish(rgb_raw_camera_info);
             }
-
-            // We can only rectify the color into the depth co-ordinates if the depth camera is 
-            // enabled and processing depth data
-            // Only create rgb rect frame when we are using a device or we have a synchronized image.
-            // Recordings may not have synchronized captures. For unsynchronized captures image skip rgb rect frame.
-            if (params_.depth_enabled && 
-                (calibration_data_.k4a_calibration_.depth_mode != K4A_DEPTH_MODE_PASSIVE_IR) && 
-                (rgb_rect_publisher_.getNumSubscribers() > 0 || rgb_rect_camerainfo_publisher_.getNumSubscribers() > 0) &&
-                (k4a_device_ || (capture.get_color_image() != nullptr && capture.get_depth_image() != nullptr)))
+            else if (params_.color_format == "bgra")
             {
-                result = getRbgFrame(capture, rgb_rect_frame, true /* rectified */);
-            
-                if (result != K4A_RESULT_SUCCEEDED)
+                if ((rgb_raw_publisher_.getNumSubscribers() > 0 || rgb_raw_camerainfo_publisher_.getNumSubscribers() > 0) &&
+                    (k4a_device_ || capture.get_color_image() != nullptr))
                 {
-                    ROS_ERROR_STREAM("Failed to get rectifed depth frame");
-                    ros::shutdown();
-                    return;
+                    result = getRbgFrame(capture, rgb_raw_frame);
+
+                    if (result != K4A_RESULT_SUCCEEDED)
+                    {
+                        ROS_ERROR_STREAM("Failed to get RGB frame");
+                        ros::shutdown();
+                        return;
+                    }
+
+                    capture_time = timestampToROS(capture.get_color_image().get_device_timestamp());
+                    printTimestampDebugMessage("Color image", capture_time);
+
+                    rgb_raw_frame->header.stamp =  capture_time;
+                    rgb_raw_frame->header.frame_id = calibration_data_.tf_prefix_ + calibration_data_.rgb_camera_frame_;
+                    rgb_raw_publisher_.publish(rgb_raw_frame);
+
+                    // Re-synchronize the header timestamps since we cache the camera calibration message
+                    rgb_raw_camera_info.header.stamp = capture_time;
+                    rgb_raw_camerainfo_publisher_.publish(rgb_raw_camera_info);
                 }
 
-                capture_time = timestampToROS(capture.get_color_image().get_device_timestamp());
-                printTimestampDebugMessage("Color image", capture_time);
+                // We can only rectify the color into the depth co-ordinates if the depth camera is
+                // enabled and processing depth data
+                // Only create rgb rect frame when we are using a device or we have a synchronized image.
+                // Recordings may not have synchronized captures. For unsynchronized captures image skip rgb rect frame.
+                if (params_.depth_enabled &&
+                    (calibration_data_.k4a_calibration_.depth_mode != K4A_DEPTH_MODE_PASSIVE_IR) &&
+                    (rgb_rect_publisher_.getNumSubscribers() > 0 || rgb_rect_camerainfo_publisher_.getNumSubscribers() > 0) &&
+                    (k4a_device_ || (capture.get_color_image() != nullptr && capture.get_depth_image() != nullptr)))
+                {
+                    result = getRbgFrame(capture, rgb_rect_frame, true /* rectified */);
 
-                rgb_rect_frame->header.stamp = capture_time;
-                rgb_rect_frame->header.frame_id = calibration_data_.tf_prefix_ + calibration_data_.depth_camera_frame_;
-                rgb_rect_publisher_.publish(rgb_rect_frame);
+                    if (result != K4A_RESULT_SUCCEEDED)
+                    {
+                        ROS_ERROR_STREAM("Failed to get rectifed depth frame");
+                        ros::shutdown();
+                        return;
+                    }
 
-                // Re-synchronize the header timestamps since we cache the camera calibration message
-                rgb_rect_camera_info.header.stamp = capture_time;
-                rgb_rect_camerainfo_publisher_.publish(rgb_rect_camera_info);
+                    capture_time = timestampToROS(capture.get_color_image().get_device_timestamp());
+                    printTimestampDebugMessage("Color image", capture_time);
+
+                    rgb_rect_frame->header.stamp = capture_time;
+                    rgb_rect_frame->header.frame_id = calibration_data_.tf_prefix_ + calibration_data_.depth_camera_frame_;
+                    rgb_rect_publisher_.publish(rgb_rect_frame);
+
+                    // Re-synchronize the header timestamps since we cache the camera calibration message
+                    rgb_rect_camera_info.header.stamp = capture_time;
+                    rgb_rect_camerainfo_publisher_.publish(rgb_rect_camera_info);
+                }
             }
         }
 

--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -90,8 +90,9 @@ K4AROSDevice::K4AROSDevice(const NodeHandle &n, const NodeHandle &p) : k4a_devic
         {
             if (params_.color_format == "jpeg" && record_config.color_format != K4A_IMAGE_FORMAT_COLOR_MJPG)
             {
-                ROS_WARN("Converting color images to K4A_IMAGE_FORMAT_COLOR_MJPG is not supported.");
-                params_.color_format = "bgra";
+                ROS_FATAL("Converting color images to K4A_IMAGE_FORMAT_COLOR_MJPG is not supported.");
+                ros::requestShutdown();
+                return;
             }
             if (params_.color_format == "bgra" && record_config.color_format != K4A_IMAGE_FORMAT_COLOR_BGRA32)
             {

--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -86,9 +86,17 @@ K4AROSDevice::K4AROSDevice(const NodeHandle &n, const NodeHandle &p) : k4a_devic
             params_.rgb_point_cloud = false;
         }
         // This is necessary because at the moment there are only checks in place which use BgraPixel size
-        else if (params_.color_enabled && record_config.color_track_enabled && record_config.color_format != K4A_IMAGE_FORMAT_COLOR_BGRA32)
+        else if (params_.color_enabled && record_config.color_track_enabled)
         {
-            k4a_playback_handle_.set_color_conversion(K4A_IMAGE_FORMAT_COLOR_BGRA32);
+            if (params_.color_format == "jpeg" && record_config.color_format != K4A_IMAGE_FORMAT_COLOR_MJPG)
+            {
+                ROS_WARN("Converting color images to K4A_IMAGE_FORMAT_COLOR_MJPG is not supported.");
+                params_.color_format = "bgra";
+            }
+            if (params_.color_format == "bgra" && record_config.color_format != K4A_IMAGE_FORMAT_COLOR_BGRA32)
+            {
+                k4a_playback_handle_.set_color_conversion(K4A_IMAGE_FORMAT_COLOR_BGRA32);
+            }
         }
 
         // Disable depth if the recording has neither ir track nor depth track

--- a/src/k4a_ros_device_params.cpp
+++ b/src/k4a_ros_device_params.cpp
@@ -167,6 +167,13 @@ k4a_result_t K4AROSDeviceParams::GetDeviceConfig(k4a_device_configuration_t *con
         return K4A_RESULT_FAILED;
     }
 
+    // Ensure that color image contains RGB pixels instead of compressed JPEG data.
+    if (rgb_point_cloud && color_format == "jpeg")
+    {
+        ROS_ERROR_STREAM("Incompatible options: cannot generate RGB point cloud if color format is JPEG.");
+        return K4A_RESULT_FAILED;
+    }
+
     return K4A_RESULT_SUCCEEDED;
 }
 

--- a/src/k4a_ros_device_params.cpp
+++ b/src/k4a_ros_device_params.cpp
@@ -17,8 +17,6 @@
 
 k4a_result_t K4AROSDeviceParams::GetDeviceConfig(k4a_device_configuration_t *configuration)
 {
-    configuration->color_format = K4A_IMAGE_FORMAT_COLOR_BGRA32;
-
     configuration->depth_delay_off_color_usec = 0;
     configuration->wired_sync_mode = K4A_WIRED_SYNC_MODE_STANDALONE;
     configuration->subordinate_delay_off_master_usec = 0;
@@ -32,6 +30,22 @@ k4a_result_t K4AROSDeviceParams::GetDeviceConfig(k4a_device_configuration_t *con
     }
     else
     {
+        ROS_INFO_STREAM("Setting RGB Camera Format: " << color_format);
+
+        if (color_format == "jpeg")
+        {
+            configuration->color_format = K4A_IMAGE_FORMAT_COLOR_MJPG;
+        }
+        else if (color_format == "bgra")
+        {
+            configuration->color_format = K4A_IMAGE_FORMAT_COLOR_BGRA32;
+        }
+        else
+        {
+            ROS_ERROR_STREAM("Invalid RGB Camera Format: " << color_format);
+            return K4A_RESULT_FAILED;
+        }
+
         ROS_INFO_STREAM("Setting RGB Camera Resolution: " << color_resolution);
 
         if (color_resolution == "720P")


### PR DESCRIPTION
Enable to publish JPEG image at `rgb/image_raw/compressed` so that clients can subscribe to the compressed image at `rgb/image_raw` via `compressed_image_transport`. This feature is useful when the images are received/consumed by remote clients and the local host  is not powerful enough to decompress the JPEG images. 

<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #20

### Description of the changes:
This PR implements the technique described in the following site. http://wiki.ros.org/compressed_image_transport#Publishing_compressed_images_directly

- Add `color_format` ROS param to enable publishing JPEG images without image decompression on the host computer.
- If `color_format` is `jpeg`, 
  - JPEG images are published at `/rgb/image_raw/compressed`   
  - `/rgb/image_raw` is not advertised (to avoid confusion).
  - `/rgb_to_depth/image_raw` does not publish.
  - `rgb_point_cloud` ROS param must be `false`.


<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
manual/ad-hoc testing
