### PR TITLE
Fix entire transformation tree to match physical sensor + calibration

### DIFF
--- a/include/azure_kinect_ros_driver/k4a_calibration_transform_data.h
+++ b/include/azure_kinect_ros_driver/k4a_calibration_transform_data.h
@@ -57,14 +57,12 @@ private:
     void printCameraCalibration(k4a_calibration_camera_t& calibration);
     void printExtrinsics(k4a_calibration_extrinsics_t& extrinsics);
 
-    void publishRgbToBaseTf();
-    void publishImuToBaseTf();
+    void publishRgbToDepthTf();
+    void publishImuToDepthTf();
     void publishDepthToBaseTf();
 
     tf2::Quaternion getDepthToBaseRotationCorrection();
     tf2::Vector3    getDepthToBaseTranslationCorrection();
-    tf2::Quaternion getImuToDepthRotationCorrection();
-    tf2::Quaternion getColorToDepthRotationCorrection();
 
     tf2_ros::StaticTransformBroadcaster static_broadcaster_;
 };

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -1,4 +1,4 @@
-<!-- 
+<!--
 Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 -->
@@ -28,14 +28,14 @@ Licensed under the MIT License.
   <arg name="body_tracking_smoothing_factor"  default="0.0" />    <!-- Set between 0 for no smoothing and 1 for full smoothing -->
 
   <node pkg="azure_kinect_ros_driver" type="node" name="node" output="screen" required="$(arg required)">
-    <param name="depth_enabled"     type="bool"   value="$(arg depth_enabled)" /> 
-    <param name="depth_mode"        type="string" value="$(arg depth_mode)" /> 
-    <param name="color_enabled"     type="bool"   value="$(arg color_enabled)" /> 
+    <param name="depth_enabled"     type="bool"   value="$(arg depth_enabled)" />
+    <param name="depth_mode"        type="string" value="$(arg depth_mode)" />
+    <param name="color_enabled"     type="bool"   value="$(arg color_enabled)" />
     <param name="color_format"      type="string" value="$(arg color_format)" />
-    <param name="color_resolution"  type="string" value="$(arg color_resolution)" /> 
-    <param name="fps"               type="int"    value="$(arg fps)" /> 
-    <param name="point_cloud"       type="bool"   value="$(arg point_cloud)" /> 
-    <param name="rgb_point_cloud"   type="bool"   value="$(arg rgb_point_cloud)" /> 
+    <param name="color_resolution"  type="string" value="$(arg color_resolution)" />
+    <param name="fps"               type="int"    value="$(arg fps)" />
+    <param name="point_cloud"       type="bool"   value="$(arg point_cloud)" />
+    <param name="rgb_point_cloud"   type="bool"   value="$(arg rgb_point_cloud)" />
     <param name="sensor_sn"         type="string" value="$(arg sensor_sn)" />
     <param name="tf_prefix"         type="string" value="$(arg tf_prefix)" />
     <param name="recording_file"          type="string" value="$(arg recording_file)" />

--- a/src/k4a_calibration_transform_data.cpp
+++ b/src/k4a_calibration_transform_data.cpp
@@ -82,18 +82,13 @@ void K4ACalibrationTransformData::initialize(const K4AROSDeviceParams params)
             getColorWidth() * (int)sizeof(DepthPixel));
     }
 
-    // Publish various transforms needed by ROS
-    publishImuToBaseTf();
-
-    if (depthEnabled)
-    {
-        publishDepthToBaseTf();
-    }
-
-    if (colorEnabled)
-    {
-        publishRgbToBaseTf();
-    }
+    // Publish various transforms needed by ROS.
+    // We publish all TFs all the time, even if the respective sensor data
+    // output is off. This allows us to just use the SDK calibrations, and one
+    // cosmetic TF output between the depth and the base.
+    publishDepthToBaseTf();
+    publishImuToDepthTf();
+    publishRgbToDepthTf();
 }
 
 int K4ACalibrationTransformData::getDepthWidth()
@@ -178,59 +173,27 @@ void K4ACalibrationTransformData::printExtrinsics(k4a_calibration_extrinsics_t& 
     ROS_INFO_STREAM("\t\t\t Rotation[2]: " << extrinsics.rotation[6] << ", " << extrinsics.rotation[7] << ", " << extrinsics.rotation[8]);
 }
 
-void K4ACalibrationTransformData::publishRgbToBaseTf()
+void K4ACalibrationTransformData::publishRgbToDepthTf()
 {
-    k4a_float3_t origin = {0.0f, 0.0f, 0.0f};
-    k4a_float3_t target = {0.0f, 0.0f, 0.0f};
-
-    // Compute the offset of the RGB camera assembly from the depth camera origin
-    target = k4a_calibration_.convert_3d_to_3d(
-        origin,
-        K4A_CALIBRATION_TYPE_DEPTH,
-        K4A_CALIBRATION_TYPE_COLOR);
-
-    ROS_INFO_STREAM("Depth -> RGB offset: ( " << target.xyz.x << ", " << target.xyz.y << ", " << target.xyz.z << " )");
+    k4a_calibration_extrinsics_t* rgb_extrinsics = &k4a_calibration_.extrinsics[K4A_CALIBRATION_TYPE_DEPTH][K4A_CALIBRATION_TYPE_COLOR];
+    tf2::Vector3 depth_to_rgb_translation(rgb_extrinsics->translation[0] / 1000.0f, rgb_extrinsics->translation[1] / 1000.0f,
+                                         rgb_extrinsics->translation[2] / 1000.0f);
+    tf2::Matrix3x3 depth_to_rgb_rotation(rgb_extrinsics->rotation[0], rgb_extrinsics->rotation[1], rgb_extrinsics->rotation[2],
+                                rgb_extrinsics->rotation[3], rgb_extrinsics->rotation[4], rgb_extrinsics->rotation[5],
+                                rgb_extrinsics->rotation[6], rgb_extrinsics->rotation[7], rgb_extrinsics->rotation[8]);
+    tf2::Transform depth_to_rgb_transform(depth_to_rgb_rotation, depth_to_rgb_translation);
 
     geometry_msgs::TransformStamped static_transform;
+    static_transform.transform = tf2::toMsg(depth_to_rgb_transform.inverse());
 
     static_transform.header.stamp = ros::Time::now();
-    static_transform.header.frame_id = tf_prefix_ + camera_base_frame_;
+    static_transform.header.frame_id = tf_prefix_ + depth_camera_frame_;
     static_transform.child_frame_id = tf_prefix_ + rgb_camera_frame_;
-
-    tf2::Vector3 extrinsic_translation((target.xyz.z / -1000.0f), (target.xyz.x / 1000.0f), (target.xyz.y / 1000.0f));
-    extrinsic_translation += getDepthToBaseTranslationCorrection();
-
-    static_transform.transform.translation.x = extrinsic_translation.x();
-    static_transform.transform.translation.y = extrinsic_translation.y();
-    static_transform.transform.translation.z = extrinsic_translation.z();
-
-    k4a_calibration_extrinsics_t* color_extrinsics = &k4a_calibration_.extrinsics[K4A_CALIBRATION_TYPE_DEPTH][K4A_CALIBRATION_TYPE_COLOR];
-
-    tf2::Matrix3x3 color_matrix(color_extrinsics->rotation[0], color_extrinsics->rotation[1], color_extrinsics->rotation[2],
-                                color_extrinsics->rotation[3], color_extrinsics->rotation[4], color_extrinsics->rotation[5],
-                                color_extrinsics->rotation[6], color_extrinsics->rotation[7], color_extrinsics->rotation[8]);
-
-    double yaw, pitch, roll;
-    color_matrix.getEulerYPR(yaw, pitch, roll);
-    ROS_INFO_STREAM("Color Roll Extrinsics (YPR): " << angles::to_degrees(yaw) << ", " << angles::to_degrees(pitch) << ", " << angles::to_degrees(roll));
-
-    tf2::Quaternion color_rotation;
-    color_rotation.setRPY(
-        yaw,
-        roll,
-        pitch);
-
-    color_rotation *= getColorToDepthRotationCorrection();
-
-    static_transform.transform.rotation.x = color_rotation.x();
-    static_transform.transform.rotation.y = color_rotation.y();
-    static_transform.transform.rotation.z = color_rotation.z();
-    static_transform.transform.rotation.w = color_rotation.w();
 
     static_broadcaster_.sendTransform(static_transform);
 }
 
-void K4ACalibrationTransformData::publishImuToBaseTf()
+void K4ACalibrationTransformData::publishImuToDepthTf()
 {
     k4a_calibration_extrinsics_t* imu_extrinsics = &k4a_calibration_.extrinsics[K4A_CALIBRATION_TYPE_DEPTH][K4A_CALIBRATION_TYPE_ACCEL];
     tf2::Vector3 depth_to_imu_translation(imu_extrinsics->translation[0] / 1000.0f, imu_extrinsics->translation[1] / 1000.0f,
@@ -252,6 +215,7 @@ void K4ACalibrationTransformData::publishImuToBaseTf()
 
 void K4ACalibrationTransformData::publishDepthToBaseTf()
 {
+    // This is a purely cosmetic transform to make the base model of the URDF look good.
     geometry_msgs::TransformStamped static_transform;
 
     static_transform.header.stamp = ros::Time::now();
@@ -282,58 +246,20 @@ void K4ACalibrationTransformData::publishDepthToBaseTf()
 
 tf2::Vector3 K4ACalibrationTransformData::getDepthToBaseTranslationCorrection()
 {
+    // These are purely cosmetic tranformations for the URDF drawing!!
     return tf2::Vector3(DEPTH_CAMERA_OFFSET_MM_X / 1000.0f, DEPTH_CAMERA_OFFSET_MM_Y / 1000.0f, DEPTH_CAMERA_OFFSET_MM_Z / 1000.0f);
 }
 
 tf2::Quaternion K4ACalibrationTransformData::getDepthToBaseRotationCorrection()
 {
+    // These are purely cosmetic tranformations for the URDF drawing!!
     tf2::Quaternion ros_camera_rotation; // ROS camera co-ordinate system requires rotating the entire camera relative to camera_base
-    tf2::Quaternion depth_rotation;      // K4A depth camera has different declinations based on the operating mode (NFOV or WFOV)
+    tf2::Quaternion depth_rotation;      // K4A has one physical camera that is about 6 degrees downward facing.
 
-    // WFOV modes are rotated down by 7.3 degrees
-    if (k4a_calibration_.depth_mode == K4A_DEPTH_MODE_WFOV_UNBINNED || k4a_calibration_.depth_mode == K4A_DEPTH_MODE_WFOV_2X2BINNED)
-    {
-        depth_rotation.setEuler(0, angles::from_degrees(-7.3), 0);
-    }
-    // NFOV modes are rotated down by 6 degrees
-    else if (k4a_calibration_.depth_mode == K4A_DEPTH_MODE_NFOV_UNBINNED || k4a_calibration_.depth_mode == K4A_DEPTH_MODE_NFOV_2X2BINNED)
-    {
-        depth_rotation.setEuler(0, angles::from_degrees(-6.0), 0);
-    }
-    // Passive IR mode doesn't have a rotation?
-    // TODO: verify that passive IR really doesn't have a rotation
-    else if (k4a_calibration_.depth_mode == K4A_DEPTH_MODE_PASSIVE_IR)
-    {
-        depth_rotation.setEuler(0, 0, 0);
-    }
-    else
-    {
-        ROS_ERROR_STREAM("Could not determine depth camera mode for rotation correction");
-        depth_rotation.setEuler(0, 0, 0);
-    }
-
+    depth_rotation.setEuler(0, angles::from_degrees(-6.0), 0);
     ros_camera_rotation.setEuler(M_PI / -2.0f, M_PI, (M_PI / 2.0f));
 
     return ros_camera_rotation * depth_rotation;
-}
-
-tf2::Quaternion K4ACalibrationTransformData::getImuToDepthRotationCorrection()
-{
-    tf2::Quaternion ros_imu_rotation;   // ROS IMU co-ordinate system requires rotating the entire IMU relative to camera_base
-    tf2::Quaternion imu_rotation;       // K4A extrinsics all contain a 6 degree offset due to being captured in NFOV mode
-
-    return ros_imu_rotation * imu_rotation;
-}
-
-tf2::Quaternion K4ACalibrationTransformData::getColorToDepthRotationCorrection()
-{
-    tf2::Quaternion ros_camera_rotation; // ROS camera co-ordinate system requires rotating the entire camera relative to camera_base
-    tf2::Quaternion color_rotation;      // K4A extrinsics all contain a 6 degree offset due to being captured in NFOV mode
-
-    color_rotation.setEuler(0, angles::from_degrees(-6.0), 0);
-    ros_camera_rotation.setEuler(M_PI / -2.0f, M_PI, (M_PI / 2.0f));
-
-    return ros_camera_rotation * color_rotation;
 }
 
 void K4ACalibrationTransformData::getDepthCameraInfo(sensor_msgs::CameraInfo &camera_info)
@@ -346,7 +272,7 @@ void K4ACalibrationTransformData::getDepthCameraInfo(sensor_msgs::CameraInfo &ca
     k4a_calibration_intrinsic_parameters_t* parameters = &k4a_calibration_.depth_camera_calibration.intrinsics.parameters;
 
     // The distortion parameters, size depending on the distortion model.
-    // For "rational_polynomial", the 5 parameters are: (k1, k2, p1, p2, k3, k4, k5, k6).
+    // For "rational_polynomial", the 8 parameters are: (k1, k2, p1, p2, k3, k4, k5, k6).
     camera_info.D = {parameters->param.k1, parameters->param.k2, parameters->param.p1, parameters->param.p2, parameters->param.k3, parameters->param.k4, parameters->param.k5, parameters->param.k6};
 
     // Intrinsic camera matrix for the raw (distorted) images.
@@ -395,7 +321,7 @@ void K4ACalibrationTransformData::getRgbCameraInfo(sensor_msgs::CameraInfo &came
     k4a_calibration_intrinsic_parameters_t* parameters = &k4a_calibration_.color_camera_calibration.intrinsics.parameters;
 
     // The distortion parameters, size depending on the distortion model.
-    // For "rational_polynomial", the 5 parameters are: (k1, k2, p1, p2, k3, k4, k5, k6).
+    // For "rational_polynomial", the 8 parameters are: (k1, k2, p1, p2, k3, k4, k5, k6).
     camera_info.D = {parameters->param.k1, parameters->param.k2, parameters->param.p1, parameters->param.p2, parameters->param.k3, parameters->param.k4, parameters->param.k5, parameters->param.k6};
 
     // Intrinsic camera matrix for the raw (distorted) images.

--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -744,7 +744,6 @@ k4a_result_t K4AROSDevice::getImuFrame(const k4a_imu_sample_t& sample, sensor_ms
     imu_msg->header.stamp = timestampToROS(sample.acc_timestamp_usec);
     printTimestampDebugMessage("IMU", imu_msg->header.stamp);
 
-
     // The correct convention in ROS is to publish the raw sensor data, in the
     // sensor coordinate frame. Do that here.
     imu_msg->angular_velocity.x = sample.gyro_sample.xyz.x;
@@ -1316,18 +1315,18 @@ ros::Time K4AROSDevice::timestampToROS(const std::chrono::microseconds & k4a_tim
 // Converts a k4a_imu_sample_t timestamp to a ros::Time object
 ros::Time K4AROSDevice::timestampToROS(const uint64_t & k4a_timestamp_us)
 {
-      ros::Duration duration_since_device_startup(k4a_timestamp_us / 1e6);
+    ros::Duration duration_since_device_startup(k4a_timestamp_us / 1e6);
 
-      // Set the time base if it is not set yet.
-      if (start_time_.isZero())
-      {
-        const ros::Duration transmission_delay(0.005);
-        ROS_INFO_STREAM("Setting the time base using a k4a_imu_sample_t sample. "
-          "Assuming the transmission delay to be " << transmission_delay.toSec() * 1000.0 << " ms.");
-        start_time_ = ros::Time::now() - duration_since_device_startup - transmission_delay;
-      }
-      return start_time_ + duration_since_device_startup;
+    // Set the time base if it is not set yet.
+    if (start_time_.isZero())
+    {
+      const ros::Duration transmission_delay(0.005);
+      ROS_INFO_STREAM("Setting the time base using a k4a_imu_sample_t sample. "
+        "Assuming the transmission delay to be " << transmission_delay.toSec() * 1000.0 << " ms.");
+      start_time_ = ros::Time::now() - duration_since_device_startup - transmission_delay;
     }
+    return start_time_ + duration_since_device_startup;
+}
 
 void printTimestampDebugMessage(const std::string name, const ros::Time & timestamp)
 {


### PR DESCRIPTION
## Fixes #
Fixes https://github.com/microsoft/Azure_Kinect_ROS_Driver/issues/82
Fixes https://github.com/microsoft/Azure_Kinect_ROS_Driver/issues/85
Fixes https://github.com/microsoft/Azure_Kinect_ROS_Driver/issues/42

### Description of the changes:
The issues are described in more detail in this issue: https://github.com/microsoft/Azure_Kinect_ROS_Driver/issues/85
As a quick summary:
- Removes physically inaccurate differences in *physical position* of the depth sensor depending on the depth sensor illumination mode (i.e., TF of the *depth camera sensor frame* was changing based on which *illuminator* was getting used)
- Removes unnecessary and incorrect transformations to the raw IMU data
- Removes unnecessary and differently incorrect transformations of the IMU TF frame
- Re-forms the TF tree to have the IMU and RGB camera frames have the depth frame as parent, which allows us to simply use the calibrations directly from the sensor rather than hand-code transformations through the *cosmetic-only* base frame
- Removes the unnecessary use of `convert_3d_to_3d` to get the translation between depth and IMU and depth and RGB sensor (which is already available as the translation in the calibration), thereby fixing the driver crash when the depth stream is disabled (#42)
- Remove comments that are incorrect based on what is happening (i.e., see `getPointcloud` method), and unnecessary negations that are undone 6 lines later
- A small number of whitespace changes, stripping trailing whitespace off ends of lines as my editor does this automatically.

**THIS IS A BREAKING CHANGE IF YOU WERE RELYING ON THE INCORRECT TFS BEFORE.**

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

# Screenshots
Please refer to #85 for more in-depth explanation of problems
## Before:
![Screenshot from 2019-10-14 10-25-07](https://user-images.githubusercontent.com/5616392/66737778-291b1f00-ee6d-11e9-8d65-2fe7f76ef3b9.png)

## After:
![Screenshot from 2019-10-14 12-19-11](https://user-images.githubusercontent.com/5616392/66751968-97bda400-ee90-11e9-8a2e-d201974cf33d.png)


# RGB-IMU Calibration: On-Board vs. From Kalibr
Please refer to https://github.com/microsoft/Azure-Kinect-Sensor-SDK/issues/807 for more explanation of the calibration procedure

## Flashed On-board Calibration
We take this as the 'ground truth' of what the output of calibrating the sensor with a tool like kalibr (  https://github.com/ethz-asl/kalibr ) should be.

```
[ INFO] [1569313697.105965997]: K4A[0] : 000505491912
[ INFO] [1569313697.156498158]: K4A Serial Number: 000505491912

[ INFO] [1569313978.671536525]:    IMU (Color to IMU):
[ INFO] [1569313978.671561941]:      Extrinsics:
[ INFO] [1569313978.671593767]:        Translation: -47.0323, -28.9455, 2.72662
[ INFO] [1569313978.671626060]:        Rotation[0]: 0.00647993, 0.0104534, -0.999924
[ INFO] [1569313978.671657840]:        Rotation[1]: -0.999972, 0.00371822, -0.00644136
[ INFO] [1569313978.671690342]:        Rotation[2]: 0.0036506, 0.999938, 0.0104773
[ INFO] [1569313978.671719551]:    IMU (IMU to Color):
[ INFO] [1569313978.671746117]:      Extrinsics:
[ INFO] [1569313978.671776980]:        Translation: -28.6499, -2.12717, -47.2437
[ INFO] [1569313978.671809872]:        Rotation[0]: 0.00647993, -0.999972, 0.0036506
[ INFO] [1569313978.671841397]:        Rotation[1]: 0.0104534, 0.00371822, 0.999938
[ INFO] [1569313978.671873030]:        Rotation[2]: -0.999924, -0.00644136, 0.0104773
```

##  Before:
If we calibrate with kalibr before this PR, we get the following results:
```
Transformation (cam0):
-----------------------
T_ci:  (imu0 to cam0):
[[-0.00195238 -0.99998546  0.00502596 -0.00625365]
 [-0.02003373 -0.00498585 -0.99978687 -0.1376281 ]
 [ 0.9997974  -0.00205265 -0.02002371 -0.07244309]
 [ 0.          0.          0.          1.        ]]

T_ic:  (cam0 to imu0):
[[-0.00195238 -0.02003373  0.9997974   0.069659  ]
 [-0.99998546 -0.00498585 -0.00205265 -0.00708845]
 [ 0.00502596 -0.99978687 -0.02002371 -0.13901792]
 [ 0.          0.          0.          1.        ]]

timeshift cam0 to imu0: [s] (t_imu = t_cam + shift)
0.0190326802542
```

Which are clearly 180 degrees off from what the flashed calibration is, because the raw IMU data is transformed and the extrinsics are wrong.

## After:
```
Transformation (cam0):
-----------------------
T_ci:  (imu0 to cam0): 
[[ 0.00113664 -0.99998531 -0.00529885 -0.04603032]
 [ 0.01188567 -0.00528497  0.9999154  -0.01143665]
 [-0.99992872 -0.00119953  0.01187948 -0.01968508]
 [ 0.          0.          0.          1.        ]]

T_ic:  (cam0 to imu0): 
[[ 0.00113664  0.01188567 -0.99992872 -0.01949542]
 [-0.99998531 -0.00528497 -0.00119953 -0.0461137 ]
 [-0.00529885  0.9999154   0.01187948  0.01142562]
 [ 0.          0.          0.          1.        ]]

timeshift cam0 to imu0: [s] (t_imu = t_cam + shift)
0.0195743892915
```

Which is now clearly matching the on-board calibration much more closely. Note that it is difficult to get a 'perfect' translation for IMU-Cam calibration, but the values now also much more closely match the CAD.

