### PR TITLE
Fix body marker orientation

### DIFF
--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -730,10 +730,10 @@ k4a_result_t K4AROSDevice::getBodyMarker(const k4abt_body_t& body, MarkerPtr mar
   marker_msg->pose.position.x = position.v[0] / 1000.0f;
   marker_msg->pose.position.y = position.v[1] / 1000.0f;
   marker_msg->pose.position.z = position.v[2] / 1000.0f;
-  marker_msg->pose.orientation.x = orientation.v[0];
-  marker_msg->pose.orientation.y = orientation.v[1];
-  marker_msg->pose.orientation.z = orientation.v[2];
-  marker_msg->pose.orientation.w = orientation.v[3];
+  marker_msg->pose.orientation.w = orientation.wxyz.w;
+  marker_msg->pose.orientation.x = orientation.wxyz.x;
+  marker_msg->pose.orientation.y = orientation.wxyz.y;
+  marker_msg->pose.orientation.z = orientation.wxyz.z;
 
   return K4A_RESULT_SUCCEEDED;
 }


### PR DESCRIPTION
## Fixes #
In constructing the body marker, the conversion from [k4a_quaternion_t](https://microsoft.github.io/Azure-Kinect-Body-Tracking/release/0.9.x/unionk4a__quaternion__t.html) to [geometry_msgs::Quaternion](http://docs.ros.org/melodic/api/geometry_msgs/html/msg/Quaternion.html) was not right because of their inconsistency in the ordering of the quaternion components (wxyz/xyzw). 

p.s. I figured this was a minor and easy-to-fix bug so I skipped the step of filing the bug in Issues.

### Description of the changes:
- Make sure the four components of the k4a quaternion are assigned to the correct data members in the body marker message.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
I created a tf broadcaster for the body markers and inspect the body joint orientation in rviz to make sure it is consistent with [that](https://docs.microsoft.com/en-us/azure/Kinect-dk/media/concepts/joint-coordinates.png) in the official doc.
