### PR TITLE
Initialise device_to_realtime_offset_ as 0

### DIFF
--- a/include/azure_kinect_ros_driver/k4a_ros_device.h
+++ b/include/azure_kinect_ros_driver/k4a_ros_device.h
@@ -157,7 +157,7 @@ class K4AROSDevice
   k4abt::tracker k4abt_tracker_;
 #endif
 
-  std::chrono::nanoseconds device_to_realtime_offset_;
+  std::chrono::nanoseconds device_to_realtime_offset_{0};
 
   // Thread control
   volatile bool running_;


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here: 
     e.g. ## Fixes #300. 
-->
## Fixes #130

### Description of the changes:
Default value for `device_to_realtime_offset_` as it is used in:
```
  // This will give INCORRECT timestamps until the first image.
  if (device_to_realtime_offset_.count() == 0)
  {
    initializeTimestampOffset(k4a_timestamp_us);
  }
```

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

