### PR TITLE
Fixing the CI scheduled build break.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
         wget https://download.microsoft.com/download/e/6/6/e66482b2-b6c1-4e34-bfee-95294163fc40/Azure%20Kinect%20SDK%201.3.0.exe -OutFile sdk.exe
         $p = Start-Process -PassThru -FilePath ".\sdk.exe" -Wait -NoNewWindow -ArgumentList "/passive"
         $p.WaitForExit()
-    - uses: seanyen/action-ros-ci@seanyen/recursive
+    - uses: ros-tooling/action-ros-ci@master
       with:
         package-name: azure_kinect_ros_driver
         vcs-repo-file-url: ${{ github.workspace }}/ci/deps.rosinstall

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - melodic
   schedule:
     - cron:  '0 0 */3 * *'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
         wget https://download.microsoft.com/download/e/6/6/e66482b2-b6c1-4e34-bfee-95294163fc40/Azure%20Kinect%20SDK%201.3.0.exe -OutFile sdk.exe
         $p = Start-Process -PassThru -FilePath ".\sdk.exe" -Wait -NoNewWindow -ArgumentList "/passive"
         $p.WaitForExit()
-    - uses: ros-tooling/action-ros-ci@master
+    - uses: seanyen/action-ros-ci@seanyen/recursive
       with:
         package-name: azure_kinect_ros_driver
         vcs-repo-file-url: ${{ github.workspace }}/ci/deps.rosinstall

--- a/ci/deps.rosinstall
+++ b/ci/deps.rosinstall
@@ -71,10 +71,6 @@
     uri: https://github.com/ros/nodelet_core.git
     version: indigo-devel
 - git:
-    local-name: orocos_kinematics_dynamics
-    uri: https://github.com/orocos/orocos_kinematics_dynamics.git
-    version: master
-- git:
     local-name: pluginlib
     uri: https://github.com/ros/pluginlib.git
     version: melodic-devel

--- a/ci/environment.yaml
+++ b/ci/environment.yaml
@@ -16,3 +16,4 @@ dependencies:
   - poco
   - console_bridge
   - bzip2
+  - python-orocos-kdl


### PR DESCRIPTION
A recent change in `orocos_kinematics_dynamics` triggers an edge case of `action-ros-ci`, where the `submodules` won't be cloned into the workspace, which subsequently causes the build break.

One is to wait for https://github.com/ros-tooling/action-ros-ci/pull/226 to be reviewed and merged. Or this pull request is to propose to pull the `orocos-kdl` from `conda-forge` instead to unblock the proof CI build. 