### PR TITLE
Fix rtabmap launch file to work on lower-end machines.

### DIFF
--- a/launch/slam_rtabmap.launch
+++ b/launch/slam_rtabmap.launch
@@ -1,4 +1,4 @@
-<!-- 
+<!--
 Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 -->
@@ -13,7 +13,7 @@ Licensed under the MIT License.
 
   <!-- Start the K4A sensor driver -->
   <group ns="k4a" >
-    
+
     <!-- Spawn a nodelet manager -->
     <node pkg="nodelet" type="nodelet" name="manager" args="manager" output="screen">
       <param name="num_worker_threads" value="16" />
@@ -46,6 +46,8 @@ Licensed under the MIT License.
       <param name="point_cloud"       value="false" />
       <param name="rgb_point_cloud"   value="false" />
       <param name="required"          value="true" />
+      <param name="imu_rate_target"   value="100" />
+
     </node>
 
   </group>
@@ -55,7 +57,7 @@ Licensed under the MIT License.
     <arg name="rgb_topic"          value="/k4a/rgb_to_depth/image_rect" />
     <arg name="depth_topic"        value="/k4a/depth/image_rect" />
     <arg name="camera_info_topic"  value="/k4a/depth/camera_info" />
-    <arg name="approx_sync"        value="false" />
+    <arg name="approx_sync"        value="true" />
     <arg name="frame_id"           value="camera_base" />
     <arg name="args"               value="--delete_db_on_start --Odom/ResetCountdown 2" />
   </include>


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #
- #121 
### Description of the changes:
- Change configuration of rtabmap and the driver in the slam_rtabmap.launch file. No code changes.
- IMU is requested to be output at 100 Hz instead of 1600 Hz. Ain't nobody got need for 1600 Hz.
- rtabmap approximate timesync is set to true, as the IMU timestamps aren't guaranteed to coincide exacly with the image timestamps. 

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [ ] I [built my changes] -(https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally - **no code changes**
- [x] I tested my changes with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux

Again no code changes.
See #121 for analysis of problem.

<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

