### PR TITLE
Avoiding issues with other robot_description parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,5 +142,6 @@ install(TARGETS ${PROJECT_NAME}_node ${PROJECT_NAME}_nodelet
 install(
   DIRECTORY
   launch
+  urdf
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -6,11 +6,14 @@ Licensed under the MIT License.
 <launch>
   <arg name="tf_prefix"         default="" />               <!-- Prefix added to tf frame IDs. It typically contains a trailing '_' unless empty. -->
 
-  <param name="robot_description"
-    command="xacro $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro tf_prefix:=$(arg tf_prefix)" />
-
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+  <param name="azure_description"
+    command="xacro $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro tf_prefix:=$(arg tf_prefix)/" />
+  <node name="joint_state_publisher_azure" pkg="joint_state_publisher" type="joint_state_publisher">
+    <remap from="robot_description" to="azure_description" />
+  </node>  
+  <node name="robot_state_publisher_azure" pkg="robot_state_publisher" type="robot_state_publisher">
+    <remap from="robot_description" to="azure_description" />
+  </node>
 
   <arg name="depth_enabled"           default="true" />           <!-- Enable or disable the depth camera -->
   <arg name="depth_mode"              default="WFOV_UNBINNED" />  <!-- Set the depth camera mode, which affects FOV, depth range, and camera resolution. See Azure Kinect documentation for full details. Valid options: NFOV_UNBINNED, NFOV_2X2BINNED, WFOV_UNBINNED, WFOV_2X2BINNED, and PASSIVE_IR -->

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -4,16 +4,26 @@ Licensed under the MIT License.
 -->
 
 <launch>
-  <arg name="tf_prefix"         default="" />               <!-- Prefix added to tf frame IDs. It typically contains a trailing '_' unless empty. -->
+  <arg name="tf_prefix"         default="" />                       <!-- Prefix added to tf frame IDs. It typically contains a trailing '_' unless empty. -->
+  <arg name="not_ovewrite_robot_description" default="false" />     <!-- Flag to publish a standalone azure_description instead of the default robot_descrition parameter-->
 
-  <param name="azure_description"
-    command="xacro $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro tf_prefix:=$(arg tf_prefix)/" />
-  <node name="joint_state_publisher_azure" pkg="joint_state_publisher" type="joint_state_publisher">
-    <remap from="robot_description" to="azure_description" />
-  </node>  
-  <node name="robot_state_publisher_azure" pkg="robot_state_publisher" type="robot_state_publisher">
-    <remap from="robot_description" to="azure_description" />
-  </node>
+  <group unless="$(arg not_ovewrite_robot_description)">
+    <param name="robot_description"
+      command="xacro $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro tf_prefix:=$(arg tf_prefix)" />
+    <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+  </group>
+
+  <group if="$(arg not_ovewrite_robot_description)">
+    <param name="azure_description"
+      command="xacro $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro tf_prefix:=$(arg tf_prefix)/" />
+    <node name="joint_state_publisher_azure" pkg="joint_state_publisher" type="joint_state_publisher">
+      <remap from="robot_description" to="azure_description" />
+    </node>  
+    <node name="robot_state_publisher_azure" pkg="robot_state_publisher" type="robot_state_publisher">
+      <remap from="robot_description" to="azure_description" />
+    </node>
+  </group>
 
   <arg name="depth_enabled"           default="true" />           <!-- Enable or disable the depth camera -->
   <arg name="depth_mode"              default="WFOV_UNBINNED" />  <!-- Set the depth camera mode, which affects FOV, depth range, and camera resolution. See Azure Kinect documentation for full details. Valid options: NFOV_UNBINNED, NFOV_2X2BINNED, WFOV_UNBINNED, WFOV_2X2BINNED, and PASSIVE_IR -->

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -5,16 +5,16 @@ Licensed under the MIT License.
 
 <launch>
   <arg name="tf_prefix"         default="" />                       <!-- Prefix added to tf frame IDs. It typically contains a trailing '_' unless empty. -->
-  <arg name="not_ovewrite_robot_description" default="false" />     <!-- Flag to publish a standalone azure_description instead of the default robot_descrition parameter-->
+  <arg name="overwrite_robot_description" default="true" />         <!-- Flag to publish a standalone azure_description instead of the default robot_descrition parameter-->
 
-  <group unless="$(arg not_ovewrite_robot_description)">
+  <group if="$(arg overwrite_robot_description)">
     <param name="robot_description"
       command="xacro $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro tf_prefix:=$(arg tf_prefix)" />
     <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
   </group>
 
-  <group if="$(arg not_ovewrite_robot_description)">
+  <group unless="$(arg overwrite_robot_description)">
     <param name="azure_description"
       command="xacro $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro tf_prefix:=$(arg tf_prefix)/" />
     <node name="joint_state_publisher_azure" pkg="joint_state_publisher" type="joint_state_publisher">


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #

### Description of the changes:
The _driver.launch_ file is loading the URDF file to the _robot_description_ parameter. As far as I know, this parameter is usually used by the robot and it should not be used by an external sensor. So, I think it could be great if your launch uses another _robot_description_ paramerter name, something like _azure_description_. This pull request contains the necessary changes to use this other parameter name and remap the _robot_state_publisher_ and _joint_state_publisher_ nodes to use thies new one instead of the robot_description parameter. You can also visualize it in RViz just modifying the RobotModel->Robot Description to _azure_description_.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

