### PR TITLE
Do not register disabled topic name in ROS namespace

### DIFF
--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -239,9 +239,11 @@ K4AROSDevice::K4AROSDevice(const NodeHandle& n, const NodeHandle& p)
   }
 
 #if defined(K4A_BODY_TRACKING)
-  body_marker_publisher_ = node_.advertise<MarkerArray>("body_tracking_data", 1);
+  if (params_.body_tracking_enabled) {
+    body_marker_publisher_ = node_.advertise<MarkerArray>("body_tracking_data", 1);
 
-  body_index_map_publisher_ = image_transport_.advertise("body_index_map/image_raw", 1);
+    body_index_map_publisher_ = image_transport_.advertise("body_index_map/image_raw", 1);
+  }
 #endif
 }
 

--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -234,7 +234,9 @@ K4AROSDevice::K4AROSDevice(const NodeHandle& n, const NodeHandle& p)
 
   imu_orientation_publisher_ = node_.advertise<Imu>("imu", 200);
 
-  pointcloud_publisher_ = node_.advertise<PointCloud2>("points2", 1);
+  if (params_.point_cloud || params_.rgb_point_cloud) {
+    pointcloud_publisher_ = node_.advertise<PointCloud2>("points2", 1);
+  }
 
 #if defined(K4A_BODY_TRACKING)
   body_marker_publisher_ = node_.advertise<MarkerArray>("body_tracking_data", 1);


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #

### Description of the changes:
- Don't register `points2` topic registration when `point_cloud` and `rgb_point_cloud` are `false`.
- Don't register `body_tracking_data` and `body_index_map/image_raw` topics registration when `body_tracking_enabled` is `false`.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

