### PR TITLE
Fixed compressed image format for image_transport compatibility

### DIFF
--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -447,7 +447,7 @@ k4a_result_t K4AROSDevice::getJpegRgbFrame(const k4a::capture& capture, sensor_m
   }
 
   const uint8_t* jpeg_frame_buffer = k4a_jpeg_frame.get_buffer();
-  jpeg_image->format = "jpeg";
+  jpeg_image->format = "bgra8; jpeg compressed bgr8";
   jpeg_image->data.assign(jpeg_frame_buffer, jpeg_frame_buffer + k4a_jpeg_frame.get_size());
   return K4A_RESULT_SUCCEEDED;
 }


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #

### Description of the changes:
- The current compressed image format is `jpeg`. compressed image published by `image_transport`'s format is `bgra8; jpeg compressed bgr8`. This PR modified the format to be compatible with `image_transport`.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

The result of this PR as follows.
```
$ rostopic echo /k4a/rgb/image_raw/compressed --noarr -n1
header:
  seq: 22
  stamp:
    secs: 1595593360
    nsecs: 195937704
  frame_id: "rgb_camera_link"
format: "bgra8; jpeg compressed bgr8"
data: "<array type: uint8, length: 615359>"
---
```
