### PR TITLE
Documentation update for ROS2 (foxy-devel)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(cv_bridge REQUIRED)
 
+
 ###########
 ## Build ##
 ###########
@@ -48,7 +49,7 @@ ament_target_dependencies(${PROJECT_NAME}_node rclcpp
   tf2
   tf2_ros
   tf2_geometry_msgs
-  cv_bridge) 
+  cv_bridge)
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,6 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(cv_bridge REQUIRED)
 
-
 ###########
 ## Build ##
 ###########

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For information on how to contribute, please see our [contributing guide](CONTRI
 
 ## Building
 
-The Azure Kinect ROS Driver uses catkin to build. For instructions on how to build the project please see the 
+The Azure Kinect ROS Driver uses colcon to build. For instructions on how to build the project please see the 
 [building guide](docs/building.md).
 
 ## Join Our Developer Program

--- a/cmake/Findk4a.cmake
+++ b/cmake/Findk4a.cmake
@@ -17,9 +17,17 @@ else()
     message(FATAL_ERROR "Unknown CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
 endif()
 
-# K4A versions have exactly 3 components: major.minor.rev
-if (NOT (FIND_VERSION_COUNT EQUAL 3))
-    message(FATAL_ERROR "Error: Azure Kinect SDK Version numbers contain exactly 3 components (major.minor.rev). Requested number of components: ${FIND_VERSION_COUNT}")
+# K4A versions have exactly 3 components: major.minor.rev in Windows, but 2 or 3 components in Linux
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+    if (NOT (FIND_VERSION_COUNT EQUAL 3))
+        message(FATAL_ERROR "Error: Azure Kinect SDK Version numbers contain exactly 3 components (major.minor.rev). Requested number of components: ${FIND_VERSION_COUNT}")
+    endif()
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    if (NOT (FIND_VERSION_COUNT EQUAL 3) AND NOT (FIND_VERSION_COUNT EQUAL 2) )
+        message(FATAL_ERROR "Error: Azure Kinect SDK Version numbers contain either 2 or 3 components (major.minor.rev). Requested number of components: ${FIND_VERSION_COUNT}")
+    endif()
+else()
+    message(FATAL_ERROR "Unknown CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
 endif()
 
 # First, check the ext/sdk folder for a depth engine. ALWAYS DO THIS FIRST.

--- a/docs/building.md
+++ b/docs/building.md
@@ -4,16 +4,17 @@
 
 Before trying to build the Azure Kinect ROS Driver, you will need to install two required dependencies:
 
-- ROS Melodic (Ubuntu or Windows 10)
+- ROS2 Foxy (Ubuntu 20.04 or Windows 10)
 - Azure Kinect Sensor SDK
 
 ### ROS
 
-Follow the [installation instructions](https://wiki.ros.org/Installation) for your operating system of choice: [Ubuntu](https://wiki.ros.org/Installation/Ubuntu), or [Windows](https://wiki.ros.org/Installation/Windows) to install ROS. Verify that ROS is working and that you can build sample projects in your catkin workspace before trying to build the Azure Kinect ROS Driver.
+Follow the [installation instructions](https://index.ros.org/doc/ros2/Installation/Foxy/) for your operating system of choice: [Ubuntu](https://index.ros.org/doc/ros2/Installation/Foxy/) (be sure to install [colcon](https://index.ros.org/doc/ros2/Tutorials/Colcon-Tutorial/#install-colcon)), or [Windows](https://ms-iot.github.io/ROSOnWindows/GettingStarted/SetupRos2.html) to install ROS2. Verify that ROS2 is working and that you can build sample projects in your workspace before trying to build the Azure Kinect ROS Driver.
 
 ### Azure Kinect Sensor SDK
 
-Follow the [installation instructions](https://github.com/microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/usage.md#Installation) in the Azure Kinect Sensor SDK repo to install the sensor SDK for your platform.
+If you are using Windows 10, follow the [installation instructions](https://github.com/microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/usage.md#Installation) in the Azure Kinect Sensor SDK repo to install the sensor SDK for your platform. 
+If you are using Ubuntu 20.04 the provided installation instructions will have to be modified as the binaries are not installable through the repository yet, [follow these steps](https://github.com/microsoft/Azure-Kinect-Sensor-SDK/issues/1263#issuecomment-710698591) for a work around. Be sure to [setup udev rules](https://github.com/microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/usage.md#linux-device-setup) to use the Azure Kinect SDK without being 'root'. 
 
 The Azure Kinect ROS Driver includes CMake files which will try to locate the Azure Kinect Sensor SDK. Installing the SDK in a non-default location will result in compile failures when CMake is unable to locate the SDK.
 
@@ -36,5 +37,29 @@ For more information, please consult the [Azure Kinect Sensor SDK usage guide](h
 
 ## Compiling
 
-Once the Azure Kinect Sensor SDK has been installed, the ROS node can be built using `catkin_make`. Please note that you may need to run `catkin_make --force-cmake` to update the SDK binaries which are copied into the ROS output folders.
+Once the Azure Kinect Sensor SDK has been installed, the ROS node can be built using `colcon build`. Please note that you may need to run `colcon build --force-cmake-configure` to update the SDK binaries which are copied into the ROS output folders.
 
+#### Windows 10 platform:
+Open a terminal and navigate to your workspace:
+```
+c:\opt\ros\foxy\x64\setup.bat
+git clone https://github.com/microsoft/Azure_Kinect_ROS_Driver.git -b foxy-devel
+pip3 install xacro
+cd Azure_Kinect_ROS_Driver
+colcon build 
+install\setup.bat
+```
+#### Ubuntu 20.04 platform:
+Open a terminal and navigate to your workspace:
+```
+source /opt/ros/foxy/setup.bash
+git clone https://github.com/microsoft/Azure_Kinect_ROS_Driver.git -b foxy-devel
+pip3 install xacro
+sudo apt install ros-foxy-joint-state-publisher
+cd Azure_Kinect_ROS_Driver
+colcon build 
+source install/setup.bash
+```
+
+## Troubleshooting 
+- If you are having trouble verfying Azure Kinect image streams using the k4aviewer, [try updating the drivers for your graphics card.](https://github.com/microsoft/Azure-Kinect-Sensor-SDK/issues/918). 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,8 +2,8 @@
 
 Releases of the Azure Kinect ROS Driver are a snapshot of a known-good version of the source code for a particular distribution of ROS. The current release process is:
 
-1. Pick the [ROS Distribution](http://wiki.ros.org/Distributions) you wish to publish for (currently, we only publish for ROS Melodic Morenia, but a ROS2 port is planned).
-1. Checkout and build the code for that ROS Distribution. Code for a particular distribution lives under a branch with the same name as the distribution (for example, the `melodic` branch for ROS Melodic Morenia).
+1. Pick the ROS Distribution you wish to publish for (currently, we only publish for ROS Melodic Morenia and ROS2 Foxy Fitzroy).
+1. Checkout and build the code for that ROS Distribution. Code for a particular distribution lives under a branch with the same name as the distribution (for example, the `melodic` branch for ROS Melodic Morenia and the `foxy-devel` branch for ROS2 Foxy Fitzroy).
 1. Test the ROS node on a live ROS system, using Azure Kinect DK hardware.
    - You must test that you can compile on Linux and Windows.
    - You must test that you can compile by installing the Azure Kinect Sensor SDK to the system path. On Windows, this means installing the Azure Kinect Sensor SDK with the `.msi` installer. On Linux, this means installing via the package manager.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,6 +6,26 @@ The Azure Kinect ROS Driver node exposes Azure Kinect DK sensor streams to ROS.
 
 Please see the [building guide](building.md).
 
+## Running the driver 
+
+#### In the same terminal you built and sourced your workspace launch the driver:
+```
+ros2 launch azure_kinect_ros_driver driver.launch.py
+```
+#### Launch Rviz2 for visualization of driver output streams: 
+Windows 10 platform:
+```
+c:\opt\ros\foxy\x64\setup.bat
+rviz2
+```
+Ubuntu 20.04 platform:
+```
+source /opt/ros/foxy/setup.bash
+rviz2
+```
+
+Once Rviz2 launches change "Fixed Frame" to "camera_body". Visualize the image streams outputted by the driver by adding the topics to Rviz2.
+
 ### Parameters
 
 The Azure Kinect ROS Driver node accepts a number of [ROS Parameters](http://wiki.ros.org/Parameter%20Server) to configure the Azure Kinect DK sensor. Since the node uses the ROS parameter server, these parameters can be set in the usual ROS ways (on the command line, in a launch file, through the parameter server, etc..).

--- a/package.xml
+++ b/package.xml
@@ -17,13 +17,13 @@
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
+  <depend>visualization_msgs</depend>
   <depend>image_transport</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>angles</depend>
-  <depend>xacro</depend>
   <depend>cv_bridge</depend>
 
   <export>


### PR DESCRIPTION
### Description of the changes:
- Updated documentation to reflect usage with ROS2 
- Fixed an Ubuntu build error that resulted from k4a version number. 

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Required before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device
- [ ] I changed both the ROS1 and ROS2 branches

<!-- Please test on both Windows and Linux as well as ROS1 and ROS2. Please check off the appropriate boxes with [x]  -->
### I tested changes on: 
- [x] Windows
- [x] Linux
- [ ] ROS1
- [x] ROS2


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Manual testing
