### PR TITLE
Fix depth/ir topic rviz2 streaming on Ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+if(MSVC)
+  add_compile_options(/wd4251)
+  # WORKAROUND: warning C4251: 'cv_bridge::CvImage::tracked_object_': class 'std::shared_ptr<const void>' needs to have dll-interface to be used by clients of class 'cv_bridge::CvImage'
+endif()
+
 ## Find packages
 
 find_package(ament_cmake REQUIRED)

--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -1278,7 +1278,9 @@ void K4AROSDevice::imuPublisherThread()
 
             RCLCPP_ERROR_EXPRESSION(this->get_logger(), result != K4A_RESULT_SUCCEEDED, "Failed to get IMU frame");
 
-            imu_orientation_publisher_->publish(*imu_msg);
+            if (imu_msg->angular_velocity.x != 0 || imu_msg->angular_velocity.y != 0 || imu_msg->angular_velocity.z != 0){
+              imu_orientation_publisher_->publish(*imu_msg);
+            }
           }
         }
 
@@ -1321,7 +1323,9 @@ void K4AROSDevice::imuPublisherThread()
 
             RCLCPP_ERROR_EXPRESSION(this->get_logger(), result != K4A_RESULT_SUCCEEDED, "Failed to get IMU frame");
 
-            imu_orientation_publisher_->publish(*imu_msg);
+            if (imu_msg->angular_velocity.x != 0 || imu_msg->angular_velocity.y != 0 || imu_msg->angular_velocity.z != 0){
+              imu_orientation_publisher_->publish(*imu_msg);
+            }
 
             last_imu_time_usec_ = sample.acc_timestamp_usec;
           }

--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -1278,7 +1278,9 @@ void K4AROSDevice::imuPublisherThread()
 
             RCLCPP_ERROR_EXPRESSION(this->get_logger(), result != K4A_RESULT_SUCCEEDED, "Failed to get IMU frame");
 
-            if (imu_msg->angular_velocity.x > DBL_EPSILON || imu_msg->angular_velocity.y > DBL_EPSILON || imu_msg->angular_velocity.z > DBL_EPSILON){
+            if (std::abs(imu_msg->angular_velocity.x) > DBL_EPSILON ||
+                std::abs(imu_msg->angular_velocity.y) > DBL_EPSILON ||
+                std::abs(imu_msg->angular_velocity.z) > DBL_EPSILON){
               imu_orientation_publisher_->publish(*imu_msg);
             }
           }
@@ -1323,7 +1325,9 @@ void K4AROSDevice::imuPublisherThread()
 
             RCLCPP_ERROR_EXPRESSION(this->get_logger(), result != K4A_RESULT_SUCCEEDED, "Failed to get IMU frame");
 
-            if (imu_msg->angular_velocity.x > DBL_EPSILON || imu_msg->angular_velocity.y > DBL_EPSILON || imu_msg->angular_velocity.z > DBL_EPSILON){
+            if (std::abs(imu_msg->angular_velocity.x) > DBL_EPSILON ||
+                std::abs(imu_msg->angular_velocity.y) > DBL_EPSILON ||
+                std::abs(imu_msg->angular_velocity.z) > DBL_EPSILON){
               imu_orientation_publisher_->publish(*imu_msg);
             }
 

--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -1278,7 +1278,7 @@ void K4AROSDevice::imuPublisherThread()
 
             RCLCPP_ERROR_EXPRESSION(this->get_logger(), result != K4A_RESULT_SUCCEEDED, "Failed to get IMU frame");
 
-            if (imu_msg->angular_velocity.x != 0 || imu_msg->angular_velocity.y != 0 || imu_msg->angular_velocity.z != 0){
+            if (imu_msg->angular_velocity.x > DBL_EPSILON || imu_msg->angular_velocity.y > DBL_EPSILON || imu_msg->angular_velocity.z > DBL_EPSILON){
               imu_orientation_publisher_->publish(*imu_msg);
             }
           }
@@ -1323,7 +1323,7 @@ void K4AROSDevice::imuPublisherThread()
 
             RCLCPP_ERROR_EXPRESSION(this->get_logger(), result != K4A_RESULT_SUCCEEDED, "Failed to get IMU frame");
 
-            if (imu_msg->angular_velocity.x != 0 || imu_msg->angular_velocity.y != 0 || imu_msg->angular_velocity.z != 0){
+            if (imu_msg->angular_velocity.x > DBL_EPSILON || imu_msg->angular_velocity.y > DBL_EPSILON || imu_msg->angular_velocity.z > DBL_EPSILON){
               imu_orientation_publisher_->publish(*imu_msg);
             }
 


### PR DESCRIPTION
## Fixes #168 

### Description of the changes:
- This fix allows `/depth/image_raw`, `/depth_to_rgb/image_raw`, and `/ir/image_raw` topics to display properly in Rviz2 on an Ubuntu 20.04 platform.
- Publish imu_msg only when there is a non-zero angular velocity. 

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Required before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device
- [ ] I changed both the ROS1 and ROS2 branches

<!-- Please test on both Windows and Linux as well as ROS1 and ROS2. Please check off the appropriate boxes with [x]  -->
### I tested changes on: 
- [x] Windows
- [x] Linux
- [x] ROS1
- [x] ROS2


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Manual testing