### PR TITLE
add 'K4A' dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@
   <depend>nodelet</depend>
   <depend>xacro</depend>
   <depend>cv_bridge</depend>
+  <depend>K4A</depend>
 
   <export>
     <nodelet plugin="${prefix}/nodelet_plugins.xml" />


### PR DESCRIPTION
This adds `K4A` as a dependency, so the [Azure-Kinect-Sensor-SDK](https://github.com/microsoft/Azure-Kinect-Sensor-SDK) can be used as pure CMake package in a ROS colcon workspace.

### Description of the changes:
- add `K4A` dependency

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Required before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device
- [ ] I changed both the ROS1 and ROS2 branches

### I tested changes on: 
- [ ] Windows
- [x] Linux
- [x] ROS1
- [ ] ROS2


Since the change only affects the build system, I just tested this with a local ROS1 build. It has no effect on the driver behaviour per se.

