### PR TITLE
remove trailing '/' from tf_prefix

### DIFF
--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -9,14 +9,14 @@ Licensed under the MIT License.
 
   <group if="$(arg overwrite_robot_description)">
     <param name="robot_description"
-      command="xacro $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro tf_prefix:=$(arg tf_prefix)/" />
+      command="xacro $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro tf_prefix:=$(arg tf_prefix)" />
     <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   </group>
 
   <group unless="$(arg overwrite_robot_description)">
     <param name="azure_description"
-      command="xacro $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro tf_prefix:=$(arg tf_prefix)/" />
+      command="xacro $(find azure_kinect_ros_driver)/urdf/azure_kinect.urdf.xacro tf_prefix:=$(arg tf_prefix)" />
     <node name="joint_state_publisher_azure" pkg="joint_state_publisher" type="joint_state_publisher">
       <remap from="robot_description" to="azure_description" />
     </node>  


### PR DESCRIPTION
## Fixes #178

### Description of the changes:
- remove the trailing `/` from the `tf_prefix`

This removes the trailing `/` from the `tf_prefix` so that the URDF links are correctly associated to the frames;
![Screenshot from 2021-02-12 18-23-15](https://user-images.githubusercontent.com/8226248/107807247-c044ff00-6d5f-11eb-9d11-802a78f8e1c5.png)

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Required before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device
- [ ] I changed both the ROS1 and ROS2 branches

<!-- Please test on both Windows and Linux as well as ROS1 and ROS2. Please check off the appropriate boxes with [x]  -->
### I tested changes on: 
- [ ] Windows
- [x] Linux
- [x] ROS1
- [ ] ROS2


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

