### PR TITLE
publish compressed depth in 16bit PNG format

### DIFF
--- a/include/azure_kinect_ros_driver/k4a_ros_device_params.h
+++ b/include/azure_kinect_ros_driver/k4a_ros_device_params.h
@@ -33,6 +33,10 @@
 #define ROS_PARAM_LIST                                                                                                 \
   LIST_ENTRY(sensor_sn, "The serial number of the sensor this node should connect to.", std::string, std::string(""))  \
   LIST_ENTRY(depth_enabled, "True if depth camera should be enabled", bool, true)                                      \
+  LIST_ENTRY(depth_unit, "Depth distance units. Options are: "+                                                        \
+                         sensor_msgs::image_encodings::TYPE_32FC1+" (32 bit float metre) or "+                         \
+                         sensor_msgs::image_encodings::TYPE_16UC1+" (16 bit integer millimetre)",                      \
+                         std::string, sensor_msgs::image_encodings::TYPE_16UC1)                                        \
   LIST_ENTRY(depth_mode,                                                                                               \
              "The mode of the depth camera. Options are: NFOV_2X2BINNED, NFOV_UNBINNED, WFOV_2X2BINNED, "              \
              "WFOV_UNBINNED, PASSIVE_IR",                                                                              \

--- a/launch/driver.launch
+++ b/launch/driver.launch
@@ -27,6 +27,7 @@ Licensed under the MIT License.
 
   <arg name="depth_enabled"           default="true" />           <!-- Enable or disable the depth camera -->
   <arg name="depth_mode"              default="WFOV_UNBINNED" />  <!-- Set the depth camera mode, which affects FOV, depth range, and camera resolution. See Azure Kinect documentation for full details. Valid options: NFOV_UNBINNED, NFOV_2X2BINNED, WFOV_UNBINNED, WFOV_2X2BINNED, and PASSIVE_IR -->
+  <arg name="depth_unit"              default="16UC1" />          <!-- Depth distance units. Options are: "32FC1" (32 bit float metre) or "16UC1" (16 bit integer millimetre) -->
   <arg name="color_enabled"           default="true" />           <!-- Enable or disable the color camera -->
   <arg name="color_format"            default="bgra" />           <!-- The format of RGB camera. Valid options: bgra, jpeg -->
   <arg name="color_resolution"        default="1536P" />          <!-- Resolution at which to run the color camera. Valid options: 720P, 1080P, 1440P, 1536P, 2160P, 3072P -->
@@ -49,6 +50,7 @@ Licensed under the MIT License.
   <node pkg="azure_kinect_ros_driver" type="node" name="azure_kinect_ros_driver" output="screen" required="$(arg required)">
     <param name="depth_enabled"     type="bool"   value="$(arg depth_enabled)" />
     <param name="depth_mode"        type="string" value="$(arg depth_mode)" />
+    <param name="depth_unit"        type="string" value="$(arg depth_unit)" />
     <param name="color_enabled"     type="bool"   value="$(arg color_enabled)" />
     <param name="color_format"      type="string" value="$(arg color_format)" />
     <param name="color_resolution"  type="string" value="$(arg color_resolution)" />

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@
   <depend>nodelet</depend>
   <depend>xacro</depend>
   <depend>cv_bridge</depend>
+  <depend>K4A</depend>
 
   <export>
     <nodelet plugin="${prefix}/nodelet_plugins.xml" />

--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -220,10 +220,20 @@ K4AROSDevice::K4AROSDevice(const NodeHandle& n, const NodeHandle& p)
   }
   rgb_raw_camerainfo_publisher_ = node_.advertise<CameraInfo>("rgb/camera_info", 1);
 
-  depth_raw_publisher_ = image_transport_.advertise("depth/image_raw", 1);
+  static const std::string depth_raw_topic = "depth/image_raw";
+  static const std::string depth_rect_topic = "depth_to_rgb/image_raw";
+  if (params_.depth_unit == sensor_msgs::image_encodings::TYPE_16UC1) {
+    // set lowest PNG compression for maximum FPS
+    node_.setParam(node_.resolveName(depth_raw_topic) + "/compressed/format", "png");
+    node_.setParam(node_.resolveName(depth_raw_topic) + "/compressed/png_level", 1);
+    node_.setParam(node_.resolveName(depth_rect_topic) + "/compressed/format", "png");
+    node_.setParam(node_.resolveName(depth_rect_topic) + "/compressed/png_level", 1);
+  }
+
+  depth_raw_publisher_ = image_transport_.advertise(depth_raw_topic, 1);
   depth_raw_camerainfo_publisher_ = node_.advertise<CameraInfo>("depth/camera_info", 1);
 
-  depth_rect_publisher_ = image_transport_.advertise("depth_to_rgb/image_raw", 1);
+  depth_rect_publisher_ = image_transport_.advertise(depth_rect_topic, 1);
   depth_rect_camerainfo_publisher_ = node_.advertise<CameraInfo>("depth_to_rgb/camera_info", 1);
 
   rgb_rect_publisher_ = image_transport_.advertise("rgb_to_depth/image_raw", 1);


### PR DESCRIPTION
## Fixes #175 

### Description of the changes:
- change default depth units to 16bit millimetre
- change default `compressed/format` for depth topics to `png`
- set lowest (fastest) compression level

In total, these changes enable the publishing of compressed depth images at 30Hz.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Required before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device
- [ ] I changed both the ROS1 and ROS2 branches

<!-- Please test on both Windows and Linux as well as ROS1 and ROS2. Please check off the appropriate boxes with [x]  -->
### I tested changes on: 
- [ ] Windows
- [x] Linux
- [x] ROS1
- [x] ROS2


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

