### PR TITLE
Fix depth/ir topic rviz2 streaming on Ubuntu

### DIFF
--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -1278,7 +1278,11 @@ void K4AROSDevice::imuPublisherThread()
 
             ROS_ASSERT_MSG(result == K4A_RESULT_SUCCEEDED, "Failed to get IMU frame");
 
-            imu_orientation_publisher_.publish(imu_msg);
+            if (std::abs(imu_msg->angular_velocity.x) > DBL_EPSILON ||
+                std::abs(imu_msg->angular_velocity.y) > DBL_EPSILON ||
+                std::abs(imu_msg->angular_velocity.z) > DBL_EPSILON){
+              imu_orientation_publisher_.publish(imu_msg);
+            }
           }
         }
 
@@ -1321,7 +1325,11 @@ void K4AROSDevice::imuPublisherThread()
 
             ROS_ASSERT_MSG(result == K4A_RESULT_SUCCEEDED, "Failed to get IMU frame");
 
-            imu_orientation_publisher_.publish(imu_msg);
+            if (std::abs(imu_msg->angular_velocity.x) > DBL_EPSILON ||
+                std::abs(imu_msg->angular_velocity.y) > DBL_EPSILON ||
+                std::abs(imu_msg->angular_velocity.z) > DBL_EPSILON){
+              imu_orientation_publisher_.publish(imu_msg);
+            }
 
             last_imu_time_usec_ = sample.acc_timestamp_usec;
           }


### PR DESCRIPTION
## Fixes #168

### Description of the changes:
- This fix is to make the melodic consistent with foxy branch. 

-  This fix allows /depth/image_raw, /depth_to_rgb/image_raw, and /ir/image_raw topics to display properly in Rviz2 on an Ubuntu 20.04 platform.

- Publish imu_msg only when there is a non-zero angular velocity.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Required before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device
- [x] I changed both the ROS1 and ROS2 branches

<!-- Please test on both Windows and Linux as well as ROS1 and ROS2. Please check off the appropriate boxes with [x]  -->
### I tested changes on: 
- [x] Windows
- [ ] Linux
- [x] ROS1
- [ ] ROS2


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Manual testing

