### PR TITLE
Declare depth params

### DIFF
--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -53,6 +53,8 @@ K4AROSDevice::K4AROSDevice()
   // Declare depth topics
   static const std::string depth_raw_topic = "depth/image_raw";
   static const std::string depth_rect_topic = "depth_to_rgb/image_raw";
+  static const std::string compressed_format = "/compressed/format";
+  static const std::string compressed_png_level = "/compressed/png_level";
 
   // Declare node parameters
   this->declare_parameter("depth_enabled");
@@ -75,10 +77,10 @@ K4AROSDevice::K4AROSDevice()
   this->declare_parameter("imu_rate_target");
   this->declare_parameter("wired_sync_mode");
   this->declare_parameter("subordinate_delay_off_master_usec");
-  this->declare_parameter({depth_raw_topic + "/compressed/format"});
-  this->declare_parameter({depth_raw_topic + "/compressed/png_level"});
-  this->declare_parameter({depth_rect_topic + "/compressed/format"});
-  this->declare_parameter({depth_rect_topic + "/compressed/png_level"});
+  this->declare_parameter({depth_raw_topic + compressed_format});
+  this->declare_parameter({depth_raw_topic + compressed_png_level});
+  this->declare_parameter({depth_rect_topic + compressed_format});
+  this->declare_parameter({depth_rect_topic + compressed_png_level});
 
   // Collect ROS parameters from the param server or from the command line
 #define LIST_ENTRY(param_variable, param_help_string, param_type, param_default_val) \
@@ -258,10 +260,10 @@ K4AROSDevice::K4AROSDevice()
 
   if (params_.depth_unit == sensor_msgs::image_encodings::TYPE_16UC1) {
     // set lowest PNG compression for maximum FPS
-    this->set_parameter({depth_raw_topic + "/compressed/format", "png"});
-    this->set_parameter({depth_raw_topic + "/compressed/png_level", 1});
-    this->set_parameter({depth_rect_topic + "/compressed/format", "png"});
-    this->set_parameter({depth_rect_topic + "/compressed/png_level", 1});
+    this->set_parameter({depth_raw_topic + compressed_format, "png"});
+    this->set_parameter({depth_raw_topic + compressed_png_level, 1});
+    this->set_parameter({depth_rect_topic + compressed_format, "png"});
+    this->set_parameter({depth_rect_topic + compressed_png_level, 1});
   }
 
   depth_raw_publisher_ = image_transport_->advertise(depth_raw_topic, 1, true);

--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -50,6 +50,10 @@ K4AROSDevice::K4AROSDevice()
   // Declare an image transport
   auto image_transport_ = new image_transport::ImageTransport(static_cast<rclcpp::Node::SharedPtr>(this));
 
+  // Declare depth topics
+  static const std::string depth_raw_topic = "depth/image_raw";
+  static const std::string depth_rect_topic = "depth_to_rgb/image_raw";
+
   // Declare node parameters
   this->declare_parameter("depth_enabled");
   this->declare_parameter("depth_mode");
@@ -71,6 +75,10 @@ K4AROSDevice::K4AROSDevice()
   this->declare_parameter("imu_rate_target");
   this->declare_parameter("wired_sync_mode");
   this->declare_parameter("subordinate_delay_off_master_usec");
+  this->declare_parameter({depth_raw_topic + "/compressed/format"});
+  this->declare_parameter({depth_raw_topic + "/compressed/png_level"});
+  this->declare_parameter({depth_rect_topic + "/compressed/format"});
+  this->declare_parameter({depth_rect_topic + "/compressed/png_level"});
 
   // Collect ROS parameters from the param server or from the command line
 #define LIST_ENTRY(param_variable, param_help_string, param_type, param_default_val) \
@@ -248,8 +256,6 @@ K4AROSDevice::K4AROSDevice()
   depth_raw_publisher_ = image_transport_->advertise("depth/image_raw", 1, true);
   depth_raw_camerainfo_publisher_ = this->create_publisher<CameraInfo>("depth/camera_info", 1);
 
-  static const std::string depth_raw_topic = "depth/image_raw";
-  static const std::string depth_rect_topic = "depth_to_rgb/image_raw";
   if (params_.depth_unit == sensor_msgs::image_encodings::TYPE_16UC1) {
     // set lowest PNG compression for maximum FPS
     this->set_parameter({depth_raw_topic + "/compressed/format", "png"});


### PR DESCRIPTION
## Fixes #175

### Description of the changes:
- These are additional fixes for issue #175 that were addressed in PR #180 for ROS 2
- Added declarations for depth related topics as these parameters cannot be set before they are declared. 

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Required before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device
- [ ] I changed both the ROS1 and ROS2 branches

<!-- Please test on both Windows and Linux as well as ROS1 and ROS2. Please check off the appropriate boxes with [x]  -->
### I tested changes on: 
- [ ] Windows
- [x] Linux
- [ ] ROS1
- [x] ROS2


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Manual
