### PR TITLE
Fixed node not shutting down, if sensor stream breaks (ROS2)

### DIFF
--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -882,7 +882,6 @@ void K4AROSDevice::framePublisherThread()
   {
     if (k4a_device_)
     {
-      // TODO: consider appropriate capture timeout based on camera framerate
       if (!k4a_device_.get_capture(&capture, waitTime))
       {
         RCLCPP_FATAL(this->get_logger(),"Failed to poll cameras: node cannot continue.");

--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -874,12 +874,16 @@ void K4AROSDevice::framePublisherThread()
   calibration_data_.getRgbCameraInfo(depth_rect_camera_info);
   calibration_data_.getDepthCameraInfo(ir_raw_camera_info);
 
+  const std::chrono::milliseconds firstFrameWaitTime = std::chrono::milliseconds(4 * 1000);
+  const std::chrono::milliseconds regularFrameWaitTime = std::chrono::milliseconds(1000 * 5 / params_.fps);
+  std::chrono::milliseconds waitTime = firstFrameWaitTime;
+
   while (running_ && rclcpp::ok())
   {
     if (k4a_device_)
     {
       // TODO: consider appropriate capture timeout based on camera framerate
-      if (!k4a_device_.get_capture(&capture, std::chrono::milliseconds(K4A_WAIT_INFINITE)))
+      if (!k4a_device_.get_capture(&capture, waitTime))
       {
         RCLCPP_FATAL(this->get_logger(),"Failed to poll cameras: node cannot continue.");
         rclcpp::shutdown();
@@ -900,6 +904,7 @@ void K4AROSDevice::framePublisherThread()
                                 capture.get_color_image().get_system_timestamp());
         }
       }
+      waitTime = regularFrameWaitTime;
     }
     else if (k4a_playback_handle_)
     {


### PR DESCRIPTION
## Fixes #181

### Description of the changes:
- This is the ROS2 equivalent change for PR #183: 
"Currently the node will break silently if the camera stops
sending data. This happens as it blocks infinite in
get_capture. This commit reduces the timeout to 5 times
the expected time it would normally take for a new frame
to arrive.
For unknown reasons, the first frame takes way longer to arrive,
therefore we wait up to four seconds for the first frame."

### Required before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device
- [x] I changed both the ROS1 and ROS2 branches

### I tested changes on: 
- [ ] Windows
- [x] Linux
- [ ] ROS1
- [x] ROS2


Manual testing
