### PR TITLE
Added loop_rate.sleep(); in the IMU publisher

### DIFF
--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -1372,6 +1372,7 @@ void K4AROSDevice::imuPublisherThread()
         }
       }
     }
+    loop_rate.sleep();
   }
 }
 


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #219

### Description of the changes:
the IMU publisher thread in the driver was taking up 100% of the CPU while running. I added loop_rate.sleep() like in the other publisher thread to fix this.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Required before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device
- [ ] I changed both the ROS1 and ROS2 branches

<!-- Please test on both Windows and Linux as well as ROS1 and ROS2. Please check off the appropriate boxes with [x]  -->
### I tested changes on: 
- [ ] Windows
- [x] Linux
- [ ] ROS1
- [x] ROS2


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
The changes were tested manually 
