### PR TITLE
set intrinsic frame id when using custom calibration

### DIFF
--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -893,6 +893,8 @@ void K4AROSDevice::framePublisherThread()
   if (ci_mngr_rgb_->isCalibrated())
   {
     rgb_raw_camera_info = depth_rect_camera_info = ci_mngr_rgb_->getCameraInfo();
+    rgb_raw_camera_info.header.frame_id = depth_rect_camera_info.header.frame_id = \
+        calibration_data_.tf_prefix_ + calibration_data_.rgb_camera_frame_;
   }
   else
   {
@@ -903,6 +905,8 @@ void K4AROSDevice::framePublisherThread()
   if (ci_mngr_ir_->isCalibrated())
   {
     depth_raw_camera_info = rgb_rect_camera_info = ir_raw_camera_info = ci_mngr_ir_->getCameraInfo();
+    depth_raw_camera_info.header.frame_id = rgb_rect_camera_info.header.frame_id = ir_raw_camera_info.header.frame_id = \
+        calibration_data_.tf_prefix_ + calibration_data_.depth_camera_frame_;
   }
   else
   {


### PR DESCRIPTION
## Fixes #209 Fixes #218 

### Description of the changes:
- sets the image `header.frame_id` when using the `CameraInfoManager` for custom calibrations

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Required before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device
- [ ] I changed both the ROS1 and ROS2 branches

<!-- Please test on both Windows and Linux as well as ROS1 and ROS2. Please check off the appropriate boxes with [x]  -->
### I tested changes on: 
- [ ] Windows
- [x] Linux
- [x] ROS1
- [ ] ROS2


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

