### PR TITLE
set 'depth_registered_filtered' to the same value as 'depth_registered'

### DIFF
--- a/launch/kinect_rgbd.launch
+++ b/launch/kinect_rgbd.launch
@@ -114,6 +114,7 @@
       <arg name="ir"                              value="ir" />
       <arg name="depth"                           value="depth" />
       <arg name="depth_registered"                value="depth_to_rgb" />
+      <arg name="depth_registered_filtered"       value="depth_to_rgb" />
 
       <arg name="rgb_processing"                  value="$(arg rgb_processing)" />
       <arg name="debayer_processing"              value="$(arg debayer_processing)" />


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #214 

### Description of the changes:
- set `depth_registered` and `depth_registered_filtered` to the same value (`depth_to_rgb`)

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Required before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device*
- [ ] I changed both the ROS1 and ROS2 branches

* tested with MKV log file

<!-- Please test on both Windows and Linux as well as ROS1 and ROS2. Please check off the appropriate boxes with [x]  -->
### I tested changes on: 
- [ ] Windows
- [x] Linux
- [x] ROS1
- [ ] ROS2


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

