### PR TITLE
fix rosdep keys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,7 @@ set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX ""
 #### AZURE KINECT SDK ######
 ############################
 
-message("Finding K4A SDK binaries")
-message("--------------------------------------------${CMAKE_MODULE_PATH}-----------------------------------------")
+message(STATUS "Finding K4A SDK binaries")
 
 # Disable cached locations for K4A SDK binaries.
 # Do this to force the search logic to happen correctly.
@@ -103,9 +102,9 @@ if (k4abt_FOUND)
   message(STATUS "Body Tracking SDK found: compiling support for Body Tracking")
   target_compile_definitions(${PROJECT_NAME}_node PUBLIC K4A_BODY_TRACKING)
   target_compile_definitions(${PROJECT_NAME}_nodelet PUBLIC K4A_BODY_TRACKING)
-  message("!!! Body Tracking SDK found: body tracking features will be available !!!")
+  message(STATUS "!!! Body Tracking SDK found: body tracking features will be available !!!")
 else()
-  message("!!! Body Tracking SDK not found: body tracking features will not be available !!!")
+  message(STATUS "!!! Body Tracking SDK not found: body tracking features will not be available !!!")
 endif()
 if(MSVC AND NOT k4abt_FOUND)
   if(CUDA_SUPPORT)

--- a/cmake/Installk4a.cmake
+++ b/cmake/Installk4a.cmake
@@ -41,9 +41,9 @@ foreach(_lib ${K4A_LIBS})
     endif()
 endforeach()
 
-message("K4A Libs: ${K4A_LIBS}")
-message("K4A DLLs: ${K4A_DLL_FILES}")
-message("K4A Install Needed: ${K4A_INSTALL_NEEDED}")
+message(STATUS "K4A Libs: ${K4A_LIBS}")
+message(STATUS "K4A DLLs: ${K4A_DLL_FILES}")
+message(STATUS "K4A Install Needed: ${K4A_INSTALL_NEEDED}")
 
 if (${K4A_INSTALL_NEEDED})
   # Tell cmake that we need to reconfigure if any of the DLL files change

--- a/package.xml
+++ b/package.xml
@@ -28,7 +28,6 @@
   <depend>nodelet</depend>
   <depend>xacro</depend>
   <depend>cv_bridge</depend>
-  <depend>K4A</depend>
   <depend>libopencv-dev</depend>
 
   <exec_depend>rgbd_launch</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -29,9 +29,9 @@
   <depend>xacro</depend>
   <depend>cv_bridge</depend>
   <depend>K4A</depend>
+  <depend>libopencv-dev</depend>
 
   <exec_depend>rgbd_launch</exec_depend>
-  <depend>OpenCV</depend>
 
   <export>
     <nodelet plugin="${prefix}/nodelet_plugins.xml" />


### PR DESCRIPTION
### Description of the changes:
This fixes the rosdep keys so that `rosdep install --from-paths src --ignore-src -y` can be used to resolve dependencies. I am also converting some messages to `STATUS` messages so that colcon/catkin do not print on `stderr` if everything goes well.

### Required before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [ ] I tested my changes with a device
- [ ] I changed both the ROS1 and ROS2 branches

<!-- Please test on both Windows and Linux as well as ROS1 and ROS2. Please check off the appropriate boxes with [x]  -->
### I tested changes on: 
- [ ] Windows
- [x] Linux
- [x] ROS1
- [ ] ROS2


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

