### PR TITLE
Use from_seconds to construct a rclcpp::Duration

### DIFF
--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -768,7 +768,7 @@ k4a_result_t K4AROSDevice::getBodyMarker(const k4abt_body_t& body, std::shared_p
 
   // Set the lifetime to 0.25 to prevent flickering for even 5fps configurations.
   // New markers with the same ID will replace old markers as soon as they arrive.
-  marker_msg->lifetime = rclcpp::Duration(0.25);
+  marker_msg->lifetime = rclcpp::Duration::from_seconds(0.25);
   marker_msg->id = body.id * 100 + jointType;
   marker_msg->type = Marker::SPHERE;
 


### PR DESCRIPTION
### Description of the changes:

Fixes compilation on ROS 2 Humble, the other constructor was deprecated & got removed

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Required before submitting a Pull Request:
- [ ] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [ ] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [ ] I tested my changes with a device
- [ ] I changed both the ROS1 and ROS2 branches

<!-- Please test on both Windows and Linux as well as ROS1 and ROS2. Please check off the appropriate boxes with [x]  -->
### I tested changes on: 
- [ ] Windows
- [ ] Linux
- [ ] ROS1
- [x] ROS2


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

