### PR TITLE
fix src/k4a_ros_device.cpp rclcpp::Duration(double)

### DIFF
--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -768,7 +768,7 @@ k4a_result_t K4AROSDevice::getBodyMarker(const k4abt_body_t& body, std::shared_p
 
   // Set the lifetime to 0.25 to prevent flickering for even 5fps configurations.
   // New markers with the same ID will replace old markers as soon as they arrive.
-  marker_msg->lifetime = rclcpp::Duration(0.25);
+  marker_msg->lifetime = rclcpp::Duration::from_seconds(0.25);
   marker_msg->id = body.id * 100 + jointType;
   marker_msg->type = Marker::SPHERE;
 


### PR DESCRIPTION
## Fixes #
Fixes #270 

fix src/k4a_ros_device.cpp rclcpp::Duration(double)

### Description of the changes:
 - rclcpp::Duration(double) does not exist in ROS humble, instead we can use rclcpp::Duration::from_seconds())

### Required before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device
- [x] I changed both the ROS1 and ROS2 branches  (the change only applies to ROS2)


### I tested changes on: 
- [x] Windows (I have no ROS on Windows but the change is minimal)
- [x] Linux
- [x] ROS1 (no change needed)
- [x] ROS2
